### PR TITLE
fixed race condition/index out of range error on startup

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -296,6 +296,7 @@ func (n *Node) Diff(node lib.Node, prefix string) (r []string, e error) {
 		for i := range eleft {
 			if eleft[i] == u {
 				eleft = append(eleft[:i], eleft[i+1:]...)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Missing break on for loop could lead to index out of range error, which would occasionally happen on startup.