### PR TITLE
node state arrays/pointers are dynamically allocated

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -149,7 +149,37 @@ func (n *Node) GetValue(url string) (v reflect.Value, e error) {
 // Returns the value, post-set (same if input if all went well)
 func (n *Node) SetValue(url string, value reflect.Value) (v reflect.Value, e error) {
 	var r reflect.Value
-	r, e = n.GetValue(url)
+	root, sub := lib.URLShift(url)
+	switch root {
+	case "type.googleapis.com":
+		p, sub := lib.URLShift(sub)
+		ext, ok := n.exts[lib.URLPush(root, p)]
+		if !ok {
+			// ok, if this is a type we know, we'll add it
+			extension, ok := Registry.Extensions[lib.URLPush(root, p)]
+			if !ok {
+				e = fmt.Errorf("unknown extension: %s", ext)
+				return
+			}
+			if err := n.AddExtension(extension.New()); e != nil {
+				e = fmt.Errorf("failed to add extension: %v", err)
+				return
+			}
+			// ok, new extension added...
+		}
+		r, e = lib.ResolveOrMakeURL(sub, reflect.ValueOf(ext))
+	case "Services":
+		p, sub := lib.URLShift(sub)
+		srv := n.GetService(p)
+		if srv == nil {
+			// we don't create services on the fly like this right now
+			e = fmt.Errorf("node does not have service instance: %s", p)
+			return
+		}
+		r, e = lib.ResolveOrMakeURL(sub, reflect.ValueOf(srv.Message()))
+	default:
+		r, e = lib.ResolveOrMakeURL(url, reflect.ValueOf(n.pb))
+	}
 	if e != nil {
 		return
 	}
@@ -444,7 +474,7 @@ const nodeFixture string = `
 {
 	"id": "Ej5FZ+ibEtOkVkJmVUQAAA==",
 	"nodename": "",
-	"runState": "INIT",
+	"runState": "UNKNOWN",
 	"physState": "PHYS_UNKNOWN",
 	"arch": "",
 	"platform": "",

--- a/extensions/IPv4/IPv4.go
+++ b/extensions/IPv4/IPv4.go
@@ -32,37 +32,39 @@ type IPv4OverEthernet struct{}
 
 func (i IPv4OverEthernet) New() proto.Message {
 	return &pb.IPv4OverEthernet{
-		Ifaces: []*pb.IPv4OverEthernet_ConfiguredInterface{
-			&pb.IPv4OverEthernet_ConfiguredInterface{
-				Eth: &pb.Ethernet{},
-				Ip:  &pb.IPv4{},
-			},
-			&pb.IPv4OverEthernet_ConfiguredInterface{
-				Eth: &pb.Ethernet{},
-				Ip:  &pb.IPv4{},
-			},
-			&pb.IPv4OverEthernet_ConfiguredInterface{
-				Eth: &pb.Ethernet{},
-				Ip:  &pb.IPv4{},
-			},
-			&pb.IPv4OverEthernet_ConfiguredInterface{
-				Eth: &pb.Ethernet{},
-				Ip:  &pb.IPv4{},
-			},
-		},
-		Routes: []*pb.IPv4{
-			&pb.IPv4{},
-			&pb.IPv4{},
-			&pb.IPv4{},
-			&pb.IPv4{},
-		},
-		DnsNameservers: []*pb.IPv4{
-			&pb.IPv4{},
-			&pb.IPv4{},
-			&pb.IPv4{},
-			&pb.IPv4{},
-		},
-		Hostname: &pb.DNSA{Ip: &pb.IPv4{}},
+		/*
+				Ifaces: []*pb.IPv4OverEthernet_ConfiguredInterface{
+					&pb.IPv4OverEthernet_ConfiguredInterface{
+						Eth: &pb.Ethernet{},
+						Ip:  &pb.IPv4{},
+					},
+					&pb.IPv4OverEthernet_ConfiguredInterface{
+						Eth: &pb.Ethernet{},
+						Ip:  &pb.IPv4{},
+					},
+					&pb.IPv4OverEthernet_ConfiguredInterface{
+						Eth: &pb.Ethernet{},
+						Ip:  &pb.IPv4{},
+					},
+					&pb.IPv4OverEthernet_ConfiguredInterface{
+						Eth: &pb.Ethernet{},
+						Ip:  &pb.IPv4{},
+					},
+				},
+				Routes: []*pb.IPv4{
+					&pb.IPv4{},
+					&pb.IPv4{},
+					&pb.IPv4{},
+					&pb.IPv4{},
+				},
+				DnsNameservers: []*pb.IPv4{
+					&pb.IPv4{},
+					&pb.IPv4{},
+					&pb.IPv4{},
+					&pb.IPv4{},
+				},
+			Hostname: &pb.DNSA{Ip: &pb.IPv4{}},
+		*/
 	}
 }
 


### PR DESCRIPTION
This allows for sparse state specifications.  We no longer need to supply empty fixtures.