### PR TITLE
Fixed oversite in previous bug #21 fix, SetValue(Dsc) should still...

### DIFF
--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -167,6 +167,7 @@ func (n *StateDifferenceEngine) SetValue(url string, v reflect.Value) (r reflect
 	var cur reflect.Value
 	cur, e = n.cfg.GetValue(url)
 	if e == nil && cur.Interface() == v.Interface() { // nothing new to set
+		r = v
 		return
 	}
 	r, e = n.cfg.SetValue(url, v)
@@ -182,6 +183,7 @@ func (n *StateDifferenceEngine) SetValueDsc(url string, v reflect.Value) (r refl
 	var cur reflect.Value
 	cur, e = n.dsc.GetValue(url)
 	if e == nil && cur.Interface() == v.Interface() { // nothing new to set
+		r = v
 		return
 	}
 	r, e = n.dsc.SetValue(url, v)


### PR DESCRIPTION
return the current value, even if there's no change.  Fixes a crash that assumed this.

(re)fixes bug #21 