### PR TITLE
More stringent locking for the Node object

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -87,11 +87,17 @@ func (n *Node) ID() lib.NodeID {
 	return NewNodeIDFromBinary(n.pb.Id)
 }
 
+// ParentID returns the NodeID of the parent of this node
 func (n *Node) ParentID() (pid lib.NodeID) {
 	n.mutex.RLock()
 	pid = NewNodeIDFromBinary(n.pb.ParentId)
 	n.mutex.RUnlock()
 	return
+}
+
+// String is important, as we can make sure prints on a Node object obey locking
+func (n *Node) String() string {
+	return fmt.Sprintf("Node<%s>", n.ID().String())
 }
 
 // JSON returns a JSON representation of the node

--- a/core/Node.go
+++ b/core/Node.go
@@ -434,11 +434,13 @@ func (n *Node) MergeDiff(node lib.Node, diff []string) (changes []string, e erro
 		m.mutex.RLock()
 		n.mutex.Lock()
 		if vm.Interface() == vn.Interface() {
+			m.mutex.RUnlock()
+			n.mutex.Unlock()
 			continue
 		}
 		vn.Set(vm)
 		m.mutex.RUnlock()
-		n.mutex.Lock()
+		n.mutex.Unlock()
 		changes = append(changes, d)
 	}
 	return

--- a/lib/types.go
+++ b/lib/types.go
@@ -91,6 +91,8 @@ type Node interface {
 	Diff(node Node, prefix string) (diff []string, e error)
 	MergeDiff(m Node, diff []string) (changes []string, e error)
 	Merge(m Node, prefix string) (changes []string, e error)
+
+	String() string
 }
 
 // Indexable can be indexed by multiple values


### PR DESCRIPTION
- Node now uses an RWMutex and is careful about always locking for Read/Write
- Node implements "String()".  This allows us to fmt.Printf("%v") without an unlocked read of the node object.
- This resolves #11, possibly others