### PR TITLE
Go tool vet Fixes

### DIFF
--- a/core/APIServer.go
+++ b/core/APIServer.go
@@ -307,7 +307,6 @@ func (s *APIServer) ServiceInit(sir *pb.ServiceInitRequest, stream pb.API_Servic
 			Config:  ctl.Config,
 		})
 	}
-	return
 }
 
 /*

--- a/core/Query.go
+++ b/core/Query.go
@@ -341,7 +341,7 @@ func (q *QueryEngine) blockingQuery(query lib.Query, r <-chan lib.QueryResponse)
 	var s chan<- lib.Query
 	t, ok := lib.QueryTypeMap[query.Type()]
 	if !ok {
-		return nil, fmt.Errorf("invalid query type: %s", query.Type())
+		return nil, fmt.Errorf("invalid query type: %v", query.Type())
 	}
 	switch t {
 	case lib.Query_SDE:

--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -80,8 +80,8 @@ func (sm *ServiceManager) Service(id string) (si lib.ServiceInstance) {
 func (sm *ServiceManager) RunService(id string) (e error) {
 	if s, ok := sm.srv[id]; ok {
 		if s.State() != lib.Service_RUN {
-			return sm.start(s)
 			s.SetState(lib.Service_RUN)
+			return sm.start(s)
 		}
 		return fmt.Errorf("service is in state, %d, cannot start", s.State())
 	}
@@ -155,7 +155,7 @@ func (sm *ServiceManager) SyncNode(n lib.Node) map[string]lib.ServiceState {
 		} else {
 			e := sm.AddServiceByModule(srv.ID(), srv.Module(), srv.Config())
 			if e != nil {
-				fmt.Printf("%v\n", e, Registry.Modules)
+				fmt.Printf("%s, %v\n", e, Registry.Modules)
 				return r
 			}
 			if ss := sm.syncState(sm.srv[srv.ID()], srv.State()); ss != lib.Service_UNKNOWN {

--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -80,8 +80,10 @@ func (sm *ServiceManager) Service(id string) (si lib.ServiceInstance) {
 func (sm *ServiceManager) RunService(id string) (e error) {
 	if s, ok := sm.srv[id]; ok {
 		if s.State() != lib.Service_RUN {
-			s.SetState(lib.Service_RUN)
-			return sm.start(s)
+			if e = sm.start(s); e == nil {
+				s.SetState(lib.Service_RUN)
+			}
+			return
 		}
 		return fmt.Errorf("service is in state, %d, cannot start", s.State())
 	}
@@ -155,7 +157,6 @@ func (sm *ServiceManager) SyncNode(n lib.Node) map[string]lib.ServiceState {
 		} else {
 			e := sm.AddServiceByModule(srv.ID(), srv.Module(), srv.Config())
 			if e != nil {
-				fmt.Printf("%s, %v\n", e, Registry.Modules)
 				return r
 			}
 			if ss := sm.syncState(sm.srv[srv.ID()], srv.State()); ss != lib.Service_UNKNOWN {

--- a/modules/vboxmanage/vboxmanage.go
+++ b/modules/vboxmanage/vboxmanage.go
@@ -44,10 +44,10 @@ const (
 
 // vbmResponse is the VBM response structure
 type vbmResponse struct {
-	Err    int32    `json:e,omitempty`
-	ErrMsg string   `json:err_msg,omitempty`
-	Off    []uint32 `json:off,omitempty`
-	On     []uint32 `json:on,omitempty`
+	Err    int32    `json:"e,omitempty"`
+	ErrMsg string   `json:"err_msg,omitempty"`
+	Off    []uint32 `json:"off,omitempty"`
+	On     []uint32 `json:"on,omitempty"`
 }
 
 // ppmut helps us succinctly define our mutations

--- a/utils/vboxapi/vboxapi.go
+++ b/utils/vboxapi/vboxapi.go
@@ -34,10 +34,10 @@ var listenPort *uint
 var verbose *bool
 
 type vbmResponse struct {
-	Err    int32    `json:e,omitempty`
-	ErrMsg string   `json:err_msg,omitempty`
-	Off    []uint32 `json:off,omitempty`
-	On     []uint32 `json:on,omitempty`
+	Err    int32    `json:"e,omitempty"`
+	ErrMsg string   `json:"err_msg,omitempty"`
+	Off    []uint32 `json:"off,omitempty"`
+	On     []uint32 `json:"on,omitempty"`
 }
 
 func main() {


### PR DESCRIPTION
Fixes found via `go tool vet $(find -name \*.go | grep -v ^./vendor)`

Appears to be one actual bug in core/ServiceManager.go, return was
before the state change.

Signed-off-by: Benjamin S. Allen <bsallen@alcf.anl.gov>