### PR TITLE
Getvalues error reporting

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -224,7 +224,7 @@ func (n *Node) SetValue(url string, value reflect.Value) (v reflect.Value, e err
 }
 
 // GetValues gets multiple values in one call
-func (n *Node) GetValues(urls []string) (v map[string]reflect.Value) {
+func (n *Node) GetValues(urls []string) (v map[string]reflect.Value, e error) {
 	v = make(map[string]reflect.Value)
 	for _, url := range urls {
 		t, e := n.GetValue(url)

--- a/core/Node.go
+++ b/core/Node.go
@@ -230,6 +230,8 @@ func (n *Node) GetValues(urls []string) (v map[string]reflect.Value, e error) {
 		t, e := n.GetValue(url)
 		if e == nil {
 			v[url] = t
+		} else {
+			e = fmt.Errorf("Error occurred while getting value %v: %v", url, e)
 		}
 	}
 	return

--- a/lib/types.go
+++ b/lib/types.go
@@ -73,7 +73,7 @@ type Node interface {
 	// Primary way to access data
 	GetValue(url string) (v reflect.Value, e error)
 	SetValue(url string, value reflect.Value) (v reflect.Value, e error)
-	GetValues(urls []string) (v map[string]reflect.Value)
+	GetValues(urls []string) (v map[string]reflect.Value, e error)
 	SetValues(valmap map[string]reflect.Value) (v map[string]reflect.Value)
 
 	GetExtensionURLs() []string

--- a/modules/pipxe/pipxe.go
+++ b/modules/pipxe/pipxe.go
@@ -142,7 +142,10 @@ func (px *PiPXE) NodeDelete(qb nodeQueryBy, q string) { // silently ignores non-
 		px.mutex.Unlock()
 		return
 	}
-	v := n.GetValues([]string{px.cfg.IpUrl, px.cfg.MacUrl})
+	v, e := n.GetValues([]string{px.cfg.IpUrl, px.cfg.MacUrl})
+	if e != nil {
+		px.api.Logf(lib.LLERROR, "error getting values: %v", e)
+	}
 	ip := IPv4.BytesToIP(v[px.cfg.IpUrl].Bytes())
 	mac := IPv4.BytesToMAC(v[px.cfg.MacUrl].Bytes())
 	delete(px.nodeBy[queryByIP], ip.String())
@@ -152,7 +155,10 @@ func (px *PiPXE) NodeDelete(qb nodeQueryBy, q string) { // silently ignores non-
 
 // NodeCreate creates a new node in our node pool -- concurrency safe
 func (px *PiPXE) NodeCreate(n lib.Node) (e error) {
-	v := n.GetValues([]string{px.cfg.IpUrl, px.cfg.MacUrl})
+	v, e := n.GetValues([]string{px.cfg.IpUrl, px.cfg.MacUrl})
+	if e != nil {
+		px.api.Logf(lib.LLERROR, "error getting values: %v", e)
+	}
 	if len(v) != 2 {
 		return fmt.Errorf("missing ip or mac for node, aborting")
 	}

--- a/modules/pipxe/tftp.go
+++ b/modules/pipxe/tftp.go
@@ -42,7 +42,10 @@ func (px *PiPXE) writeToTFTP(filename string, rf io.ReaderFrom) (e error) {
 		px.api.Logf(lib.LLDEBUG, "got TFTP request from unknown node: %s", ip.String())
 		return fmt.Errorf("got TFTP request from unknown node: %s", ip.String())
 	}
-	vs := n.GetValues([]string{"/Arch", "/Platform"})
+	vs, e := n.GetValues([]string{"/Arch", "/Platform"})
+	if e != nil {
+		px.api.Logf(lib.LLERROR, "error getting values: %v", e)
+	}
 	lfile := filepath.Join(
 		px.cfg.TftpDir,
 		vs["/Arch"].String(),

--- a/modules/rfpipower/RFPiPower.go
+++ b/modules/rfpipower/RFPiPower.go
@@ -354,9 +354,12 @@ func (pp *RFPiPower) handleMutation(m lib.Event) {
 		pp.api.Log(lib.LLINFO, "got an unexpected event type on mutation channel")
 	}
 	me := m.Data().(*core.MutationEvent)
-	vs := me.NodeCfg.GetValues([]string{ChassisURL, RankURL})
+	vs, e := me.NodeCfg.GetValues([]string{ChassisURL, RankURL})
 	// we make a speciall "nodename" consisting of <chassis>n<rank> to key by
 	// mostly for historical convenience
+	if e != nil {
+		pp.api.Logf(lib.LLERROR, "error getting values: %v", e)
+	}
 	if len(vs) != 2 {
 		pp.api.Logf(lib.LLERROR, "incomplete RPi3 data for power control: %v", vs)
 		return


### PR DESCRIPTION
Currently Node.GetValues will drop any errors that occur during Node.GetValue. This PR adds an error return value to GetValues.