### PR TITLE
fixed update to return updated node

### DIFF
--- a/core/State.go
+++ b/core/State.go
@@ -70,7 +70,7 @@ func (s *State) Update(n lib.Node) (r lib.Node, e error) {
 	idstr := n.ID().String()
 	if v, ok := s.nodes[idstr]; ok {
 		s.nodes[idstr] = n.(*Node)
-		r = v
+		r = s.nodes[idstr]
 		return
 	}
 	e = fmt.Errorf("could not update node, id does not exist: %s", idstr)


### PR DESCRIPTION
Fixes a bug where .update() would return the old, unedited node instead of the new updated node.