### PR TITLE
return the value of the update for sde updates

### DIFF
--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -479,8 +479,9 @@ func (n *StateDifferenceEngine) updateByType(dsc bool, m lib.Node) (r lib.Node, 
 			utype = StateChange_CFG_UPDATE
 		}
 		for _, u := range diff {
-			// TODO: should this include the updated value(s)?
-			evs = append(evs, NewStateChangeEvent(utype, u, reflect.Value{}))
+			_, url := lib.NodeURLSplit(u)
+			v, _ := r.GetValue(url)
+			evs = append(evs, NewStateChangeEvent(utype, u, reflect.ValueOf(v)))
 		}
 		go n.Emit(evs)
 	}


### PR DESCRIPTION
Returns the updated value to `NewStateChangeEvent` for easier debugging.

Note: I did not update `bulkUpdateByType` because I didn't see any possible way to fix that without a rewrite of the function.