### PR TITLE
replaced urlpush with sprintf to avoid beginning slash

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -377,10 +377,10 @@ func (n *Node) Diff(node lib.Node, prefix string) (r []string, e error) {
 	for _, u := range eright {
 		nodeExt, ok := m.exts[u]
 		if !ok {
-			r = append(r, lib.URLPush(prefix, u))
+			r = append(r, fmt.Sprintf("%v%v", prefix, u))
 			continue
 		}
-		d, _ := lib.MessageDiff(n.exts[u], nodeExt, lib.URLPush(prefix, u))
+		d, _ := lib.MessageDiff(n.exts[u], nodeExt, fmt.Sprintf("%v%v", prefix, u))
 		r = append(r, d...)
 		for i := range eleft {
 			if eleft[i] == u {
@@ -390,7 +390,7 @@ func (n *Node) Diff(node lib.Node, prefix string) (r []string, e error) {
 		}
 	}
 	for _, u := range eleft {
-		r = append(r, lib.URLPush(prefix, u))
+		r = append(r, fmt.Sprintf("%v%v", prefix, u))
 	}
 
 	// handle services


### PR DESCRIPTION
**Problem:**
When calling `.Diff()` to compare two nodes, the extensions will contain a leading slash in their url (for example: <nodeid>:/type.googleapis.com/proto.blah/State). This is due to how `URLPush()` works. This will cause issues with the SME because it filters out any STATE_CHANGE events that contain extensions with a leading slash.

**Solution:**
I replaced URLPush() with sprintf to just append the extension url to the node id. I didn't do extensive testing on this, but it did fix the issue with the SME filtering out my events.