### PR TITLE
Add Struct case to lib.ValueToString()

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -286,6 +286,8 @@ func ValueToString(v reflect.Value) (s string) {
 		s = fmt.Sprintf("%d", v.Int())
 	case reflect.Bool:
 		s = fmt.Sprintf("%t", v.Bool())
+	case reflect.Struct:
+		s = fmt.Sprintf("%v", v.Interface())
 	default:
 		s = fmt.Sprintf("%v", v)
 	}


### PR DESCRIPTION
This PR adds the struct case to lib.ValueToString().

An example of this issue is seen when state change events are printed to the log.
**Before:**
`12:33:39.270:kraken:DEBUG:EventDispatchEngine:dispatching event: STATE_CHANGE 91fdee9c-5312-f2bf-e1f4-16b7920846f1:type.googleapis.com/proto.PXE/State (UPDATE) 91fdee9c-5312-f2bf-e1f4-16b7920846f1:type.googleapis.com/proto.PXE/State = <proto.PXE_State Value>`
**After:**
`12:27:48.884:kraken:DEBUG:EventDispatchEngine:dispatching event: STATE_CHANGE 91fdee9c-5312-f2bf-e1f4-16b7920846f1:type.googleapis.com/proto.PXE/State (UPDATE) 91fdee9c-5312-f2bf-e1f4-16b7920846f1:type.googleapis.com/proto.PXE/State = INIT`