### PR TITLE
Cleanup any timers before deleting or changing

### DIFF
--- a/core/StateMutationEngine.go
+++ b/core/StateMutationEngine.go
@@ -1220,15 +1220,13 @@ func (sme *StateMutationEngine) handleEvent(v lib.Event) {
 			// let's print something, and then pretend it *is* new
 			sme.Log(DEBUG, "what?! we got a CREATE event for a node with an existing mutation")
 			sme.activeMutex.Lock()
-			if ok {
-				m := sme.active[node]
-				m.mutex.Lock()
-				if m.timer != nil {
-					m.timer.Stop()
-				}
-				m.mutex.Unlock()
+			m := sme.active[node]
+			m.mutex.Lock()
+			if m.timer != nil {
+				m.timer.Stop()
 			}
 			delete(sme.active, node)
+			m.mutex.Unlock()
 			sme.activeMutex.Unlock()
 		}
 		sme.startNewMutation(node)


### PR DESCRIPTION
**Problem:**
When a mutation path gets deleted or replaced in the SME, the old timer is still alive and will trigger when it expires.

**Solution:**
This PR stops any timers before a delete or replacement of the mutation path.

Tested with Vbox example.