### PR TITLE
Fix SME emitFail

### DIFF
--- a/core/StateMutationEngine.go
+++ b/core/StateMutationEngine.go
@@ -983,8 +983,8 @@ func (sme *StateMutationEngine) emitFail(start lib.Node, p *mutationPath) {
 		if r == d[1] {
 			continue
 		}
-		v, e := n.GetValue(r)
-		if e != nil {
+		v, _ := n.GetValue(r)
+		if v.Interface() == reflect.Zero(v.Type()).Interface() {
 			v, _ = nc.GetValue(r)
 		}
 		fn.SetValue(r, v)

--- a/core/StateMutationEngine.go
+++ b/core/StateMutationEngine.go
@@ -983,7 +983,10 @@ func (sme *StateMutationEngine) emitFail(start lib.Node, p *mutationPath) {
 		if r == d[1] {
 			continue
 		}
-		v, _ := nc.GetValue(r)
+		v, e := n.GetValue(r)
+		if e != nil {
+			v, _ = nc.GetValue(r)
+		}
 		fn.SetValue(r, v)
 	}
 	sme.graphMutex.RUnlock()


### PR DESCRIPTION
Fix emit fail so that it doesn't just reset all mutators to zero. It now follows this path:
1. try to devolve to a previous state in the chain
2. search the graph for a mutation node that matches what we want to fail to
3. if all else fails, set all mutators to zero.