### PR TITLE
Ignore .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ munge.key
 ssh_host_*key*
 **/.DS_Store
 /kraken-build
+**/*.swp


### PR DESCRIPTION
Modify `.gitignore` to ignore any `.swp` files created by vim.