### PR TITLE
Remove beginning slash from extensions in node.Diff

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -386,10 +386,10 @@ func (n *Node) Diff(node lib.Node, prefix string) (r []string, e error) {
 	for _, u := range eright {
 		nodeExt, ok := m.exts[u]
 		if !ok {
-			r = append(r, lib.URLPush(prefix, u))
+			r = append(r, fmt.Sprintf("%s%s", prefix, u))
 			continue
 		}
-		d, _ := lib.MessageDiff(n.exts[u], nodeExt, lib.URLPush(prefix, u))
+		d, _ := lib.MessageDiff(n.exts[u], nodeExt, fmt.Sprintf("%s%s", prefix, u))
 		r = append(r, d...)
 		for i := range eleft {
 			if eleft[i] == u {
@@ -399,7 +399,7 @@ func (n *Node) Diff(node lib.Node, prefix string) (r []string, e error) {
 		}
 	}
 	for _, u := range eleft {
-		r = append(r, lib.URLPush(prefix, u))
+		r = append(r, fmt.Sprintf("%s%s", prefix, u))
 	}
 
 	// handle services


### PR DESCRIPTION
This PR prevents node.Diff from adding a beginning slash to extensions. A beginning slash will cause issues with the SME because it filters out any STATE_CHANGE events that contain extensions with a leading slash.

This is referenced in https://github.com/hpc/kraken/issues/142

This needs a more elegant solution that isn't sprintf.