### PR TITLE
Wait to thaw until phone home

### DIFF
--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -413,6 +413,10 @@ func (sse *StateSyncEngine) callParent(p string) {
 	sse.query.Create(pn)
 
 	n.recv()
+	e = sse.query.Thaw()
+	if e != nil {
+		sse.Log(ERROR, e.Error())
+	}
 }
 
 func (sse *StateSyncEngine) nodeGetKey(id lib.NodeID) (key []byte, e error) {

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -200,7 +200,11 @@ func main() {
 	// subscribe our listener
 	k.Ctx.SubChan <- sclist
 
-	k.Sme.Thaw()
+	// Thaw if full state
+	if len(parents) == 0 {
+		k.Sme.Thaw()
+	}
+
 	// wait forever
 	for {
 		select {


### PR DESCRIPTION
A child node should wait to thaw the SME until it has successfully phoned home.