### PR TITLE
Moving mutex lock above n.exts access

### DIFF
--- a/core/Node.go
+++ b/core/Node.go
@@ -146,12 +146,12 @@ func (n *Node) GetValue(url string) (v reflect.Value, e error) {
 	switch root {
 	case "type.googleapis.com": // resolve extension
 		p, sub := lib.URLShift(sub)
+		n.mutex.RLock()
 		ext, ok := n.exts[lib.URLPush(root, p)]
 		if !ok {
 			e = fmt.Errorf("node does not have extension: %s", lib.URLPush(root, p))
 			return
 		}
-		n.mutex.RLock()
 		defer n.mutex.RUnlock()
 		return lib.ResolveURL(sub, reflect.ValueOf(ext))
 	case "Services": // resolve service


### PR DESCRIPTION
This PR moves the mutex lock in Node.GetValue above the n.exts accessor for extensions. Without this fix a concurrent map read/write is possible.