### PR TITLE
Allow system services to report ready before continuing to the next

### DIFF
--- a/core/APIServer.go
+++ b/core/APIServer.go
@@ -478,11 +478,12 @@ func (s *APIServer) LoggerInit(stream pb.API_LoggerInitServer) (e error) {
 }
 
 // Run starts the API service listener
-func (s *APIServer) Run() {
+func (s *APIServer) Run(ready chan<- interface{}) {
 	s.Log(INFO, "starting API")
 	srv := grpc.NewServer()
 	pb.RegisterAPIServer(srv, s)
 	reflection.Register(srv)
+	ready <- nil
 	if e := srv.Serve(s.ulist); e != nil {
 		s.Logf(CRITICAL, "couldn't start API service: %v", e)
 		return

--- a/core/EventDispatchEngine.go
+++ b/core/EventDispatchEngine.go
@@ -78,8 +78,9 @@ func (v *EventDispatchEngine) EventChan() chan<- []lib.Event { return v.echan }
 
 // Run is a goroutine than handles event dispatch and subscriptions
 // There's currently no way to stop this once it's started.
-func (v *EventDispatchEngine) Run() {
+func (v *EventDispatchEngine) Run(ready chan<- interface{}) {
 	v.Log(INFO, "starting EventDispatchEngine")
+	ready <- nil
 	for {
 		select {
 		case el := <-v.schan:

--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -302,7 +302,7 @@ func (n *StateDifferenceEngine) QueryChan() chan<- lib.Query {
 }
 
 // Run is a goroutine that manages queries
-func (n *StateDifferenceEngine) Run() {
+func (n *StateDifferenceEngine) Run(ready chan<- interface{}) {
 	n.Log(INFO, "starting StateDifferenceEngine")
 	// we listen for queries as well as discovery events
 	dchan := make(chan lib.Event)
@@ -314,6 +314,7 @@ func (n *StateDifferenceEngine) Run() {
 	)
 	// subscribe our discovery listener
 	n.schan <- list
+	ready <- nil
 	for {
 		select {
 		case q := <-n.qc:

--- a/core/StateMutationEngine.go
+++ b/core/StateMutationEngine.go
@@ -417,7 +417,7 @@ func (sme *StateMutationEngine) QueryChan() chan<- lib.Query {
 
 // Run is a goroutine that listens for state changes and performs StateMutation magic
 // LOCKS: all
-func (sme *StateMutationEngine) Run() {
+func (sme *StateMutationEngine) Run(ready chan<- interface{}) {
 	// on run we import all mutations in the registry
 	sme.graphMutex.Lock()
 	for mod := range Registry.Mutations {
@@ -465,6 +465,7 @@ func (sme *StateMutationEngine) Run() {
 		}()
 	}
 
+	ready <- nil
 	for {
 		select {
 		case q := <-sme.qc:

--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -260,7 +260,7 @@ func (sse *StateSyncEngine) RPCPhoneHome(ctx context.Context, in *pb.PhoneHomeRe
 }
 
 // Run is a goroutine that makes StateSyncEngine active
-func (sse *StateSyncEngine) Run() {
+func (sse *StateSyncEngine) Run(ready chan<- interface{}) {
 	rchan := make(chan recvPacket) // receive chan
 	echan := make(chan lib.Event)  // event chan
 	sse.Log(INFO, "starting StateSyncEngine")
@@ -318,6 +318,7 @@ func (sse *StateSyncEngine) Run() {
 
 	sse.Logf(INFO, "state sync is running for identity: %s", sse.self.String())
 
+	ready <- nil
 	for {
 		select {
 		case r := <-rchan: // received a hello

--- a/lib/types.go
+++ b/lib/types.go
@@ -236,7 +236,7 @@ type StateDifferenceEngine interface {
 	SetValueDsc(url string, v reflect.Value) (r reflect.Value, e error)
 	QueryChan() chan<- Query
 	// goroutine that manages engine queries
-	Run()
+	Run(chan<- interface{})
 }
 
 // An EventDispatchEngine subscribes to event sources and re-transmits events
@@ -248,7 +248,7 @@ type EventDispatchEngine interface {
 	// Send an EventListener to subscribe, or modify a subscription
 	SubscriptionChan() chan<- EventListener
 	EventChan() chan<- []Event
-	Run() // goroutine
+	Run(chan<- interface{}) // goroutine
 }
 
 // An EventListener decies if an event should be provided on this subscription.
@@ -395,7 +395,7 @@ type StateMutationEngine interface {
 	RegisterMutation(module, id string, mut StateMutation) error
 	NodeMatch(node Node) int
 	PathExists(start Node, end Node) (bool, error)
-	Run()
+	Run(chan<- interface{})
 }
 
 /*


### PR DESCRIPTION
This provides greater synchronization during core service startup and makes sure services are ready in the proper order.