### PR TITLE
Fix Incorrect /enumerables

### DIFF
--- a/modules/restapi/restapi.go
+++ b/modules/restapi/restapi.go
@@ -240,10 +240,14 @@ func (r *RestAPI) getAllEnums(w http.ResponseWriter, req *http.Request) {
 				for key, val := range enumValueMap {
 					enumOptions[val] = key
 				}
-
+				// If JSONName doesn't exists then it is the same as OrigName
+				name := p.JSONName
+				if name == "" {
+					name = p.OrigName
+				}
 				enum := extension{
-					Name:    p.OrigName,
-					Url:     lib.URLPush(k, p.OrigName),
+					Name:    name,
+					Url:     lib.URLPush(k, name),
 					Options: enumOptions,
 				}
 				extSlice = append(extSlice, enum)


### PR DESCRIPTION
Problem:
When all available enumerables with /enumerables, the "name" field had the incorrect value. 

Reason:
This is because if JSONName exists, it is what needs to be used. Note that JSONName does not exists if OrigName and JSONName would be the same. 

Solution:
Use JSONName if it exists. If JSONName doesn't exists, use OrignName.

Tested on cray system.