### PR TITLE
3/5 vboxmanage hostname

### DIFF
--- a/core/APIClient.go
+++ b/core/APIClient.go
@@ -249,7 +249,7 @@ func (a *APIClient) ServiceInit(id string, module string) (c <-chan lib.ServiceC
 			if e != nil {
 				return
 			}
-			cc <- lib.ServiceControl{Command: lib.ServiceControl_Command(ctl.Command), Config: ctl.Config}
+			cc <- lib.ServiceControl{Command: lib.ServiceControl_Command(ctl.Command)}
 		}
 	}()
 	c = cc

--- a/core/APIServer.go
+++ b/core/APIServer.go
@@ -309,19 +309,12 @@ func (s *APIServer) ServiceInit(sir *pb.ServiceInitRequest, stream pb.API_Servic
 		Command: pb.ServiceControl_INIT,
 		Config:  any,
 	})
-	if srv.Config() != nil {
-		e = stream.Send(&pb.ServiceControl{Command: pb.ServiceControl_UPDATE, Config: srv.Config()})
-		if e != nil {
-			s.Logf(ERROR, "send error: %v", e)
-		}
-	}
 	c := make(chan lib.ServiceControl)
 	srv.SetCtl(c)
 	for {
 		ctl := <-c
 		stream.Send(&pb.ServiceControl{
 			Command: pb.ServiceControl_Command(ctl.Command),
-			Config:  ctl.Config,
 		})
 	}
 }

--- a/core/APIServer.go
+++ b/core/APIServer.go
@@ -69,7 +69,6 @@ func NewAPIServer(ctx Context) *APIServer {
 		query: &ctx.Query,
 		log:   &ctx.Logger,
 		em:    NewEventEmitter(lib.Event_API),
-		sm:    ctx.Services,
 		schan: ctx.SubChan,
 		self:  ctx.Self,
 	}

--- a/core/APIServer.go
+++ b/core/APIServer.go
@@ -71,6 +71,7 @@ func NewAPIServer(ctx Context) *APIServer {
 		em:    NewEventEmitter(lib.Event_API),
 		schan: ctx.SubChan,
 		self:  ctx.Self,
+		sm:    ctx.Sm,
 	}
 	api.log.SetModule("API")
 	return api
@@ -300,7 +301,7 @@ func (s *APIServer) QueryFrozen(ctx context.Context, in *empty.Empty) (out *pb.Q
  */
 
 func (s *APIServer) ServiceInit(sir *pb.ServiceInitRequest, stream pb.API_ServiceInitServer) (e error) {
-	srv := s.sm.Service(sir.GetId())
+	srv := s.sm.GetService(sir.GetId())
 
 	self, _ := s.query.Read(s.self)
 	any, _ := ptypes.MarshalAny(self.Message())

--- a/core/Kraken.go
+++ b/core/Kraken.go
@@ -70,7 +70,8 @@ type ContextRPC struct {
 /////////////////
 
 var _ lib.Module = (*Kraken)(nil)
-var _ lib.ServiceInstance = (*Kraken)(nil)
+
+//var _ lib.ServiceInstance = (*Kraken)(nil)
 
 // A Kraken is a mythical giant squid-beast.
 type Kraken struct {

--- a/core/Kraken.go
+++ b/core/Kraken.go
@@ -38,6 +38,7 @@ type Context struct {
 	SSE     ContextSSE
 	SME     ContextSME
 	RPC     ContextRPC
+	Sm      lib.ServiceManager // API needs this
 	sdqChan chan lib.Query
 	smqChan chan lib.Query
 }
@@ -202,8 +203,9 @@ func (k *Kraken) Bootstrap() {
 	k.Ede = NewEventDispatchEngine(k.Ctx)
 	k.Ctx.SubChan = k.Ede.SubscriptionChan()
 	k.Sde = NewStateDifferenceEngine(k.Ctx, k.Ctx.sdqChan)
-	k.Sm = NewServiceManager(k.Ctx, "unix:"+k.Ctx.RPC.Path)
 	k.Ctx.Query = *NewQueryEngine(k.Ctx.sdqChan, k.Ctx.smqChan)
+	k.Sm = NewServiceManager(k.Ctx, "unix:"+k.Ctx.RPC.Path)
+	k.Ctx.Sm = k.Sm // API needs this
 
 	k.Sse = NewStateSyncEngine(k.Ctx)
 	k.Sme = NewStateMutationEngine(k.Ctx, k.Ctx.smqChan)
@@ -243,7 +245,7 @@ func (k *Kraken) Run() {
 
 	if len(k.Ctx.Parents) < 1 {
 		// set our own runstate and phystate, should we discover these instead?
-		n, _ := k.Ctx.Query.ReadDsc(k.Ctx.Self)
+		n, _ := k.Ctx.Query.Read(k.Ctx.Self)
 		dn, _ := k.Ctx.Query.ReadDsc(k.Ctx.Self)
 		n.SetValue("/PhysState", reflect.ValueOf(pb.Node_POWER_ON))
 		dn.SetValue("/PhysState", reflect.ValueOf(pb.Node_POWER_ON))

--- a/core/Node.go
+++ b/core/Node.go
@@ -511,7 +511,7 @@ func newNode() *Node {
 				Module: si.Module(),
 			}
 			if mc, ok := Registry.Modules[si.Module()].(lib.ModuleWithConfig); ok {
-				any, _ := ptypes.MarshalAny(mc.NewConfig())
+				any, _ := ptypes.MarshalAny(reflect.Zero(reflect.TypeOf(mc.NewConfig())).Interface().(proto.Message))
 				srv.Config = any
 			}
 			n.AddService(srv)

--- a/core/Node.go
+++ b/core/Node.go
@@ -506,10 +506,15 @@ func newNode() *Node {
 	for i := range Registry.ServiceInstances {
 		for j := range Registry.ServiceInstances[i] {
 			si := Registry.ServiceInstances[i][j]
-			n.AddService(&pb.ServiceInstance{
+			srv := &pb.ServiceInstance{
 				Id:     si.ID(),
 				Module: si.Module(),
-			})
+			}
+			if mc, ok := Registry.Modules[si.Module()].(lib.ModuleWithConfig); ok {
+				any, _ := ptypes.MarshalAny(mc.NewConfig())
+				srv.Config = any
+			}
+			n.AddService(srv)
 		}
 	}
 	return n

--- a/core/ServiceInstance.go
+++ b/core/ServiceInstance.go
@@ -156,7 +156,7 @@ func (si *ServiceInstance) start() (e error) {
 
 // moduleExecute does all of the necessary steps to start the service instance
 // this is the actual entry point for a new module process
-func moduleExecute(id, module, sock string) {
+func ModuleExecute(id, module, sock string) {
 	m, ok := Registry.Modules[module]
 	if !ok {
 		fmt.Printf("trying to launch non-existent module: %s", module)

--- a/core/ServiceInstance.go
+++ b/core/ServiceInstance.go
@@ -134,7 +134,7 @@ func (si *ServiceInstance) watcher() {
 func (si *ServiceInstance) start() (e error) {
 	si.mutex.Lock()
 	defer si.mutex.Unlock()
-	if si.GetState() == lib.Service_RUN {
+	if si.state == lib.Service_RUN {
 		return fmt.Errorf("cannot start service instance not in stop state")
 	}
 	if _, e = os.Stat(si.exe); os.IsNotExist(e) {

--- a/core/ServiceInstance.go
+++ b/core/ServiceInstance.go
@@ -1,9 +1,9 @@
-/* ServiceInstance.go: provides the ServiceInstance object
+/* ServiceInstance.go: provides the interface for controlling service instance processes
  *
  * Author: J. Lowell Wofford <lowell@lanl.gov>
  *
  * This software is open source software available under the BSD-3 license.
- * Copyright (c) 2018, Triad National Security, LLC
+ * Copyright (c) 2020, Triad National Security, LLC
  * See LICENSE file for details.
  */
 
@@ -16,8 +16,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 
-	"github.com/golang/protobuf/ptypes/any"
-	pb "github.com/hpc/kraken/core/proto"
 	"github.com/hpc/kraken/lib"
 )
 
@@ -28,6 +26,7 @@ import (
 var _ lib.ServiceInstance = (*ServiceInstance)(nil)
 
 // A ServiceInstance describes a service that will be built-in to the binary and exec'ed by forking
+// note: state information is stored in the node proto object, this object manages a running context
 type ServiceInstance struct {
 	id     string // ID must be unique
 	module string // name doesn't need to be unique; we can run multiple configs of the same service
@@ -35,117 +34,112 @@ type ServiceInstance struct {
 	entry  func() // needs to run as a goroutine
 	sock   string
 	cmd    *exec.Cmd
-	cfg    *any.Any
 	ctl    chan<- lib.ServiceControl
-	state  lib.ServiceState
+	wchan  chan<- lib.ServiceState
+	state  lib.ServiceState // note: these states mean a slightly different: RUN means process is running, INIT means nothing
 	m      lib.ModuleSelfService
 }
 
 // NewServiceInstance provides a new, initialized ServiceInstance object
-func NewServiceInstance(id, module string, entry func(), cfg *any.Any) *ServiceInstance {
-	ss := &ServiceInstance{
+func NewServiceInstance(id, module string, entry func()) *ServiceInstance {
+	si := &ServiceInstance{
 		id:     id,
 		module: module,
 		entry:  entry,
 		cmd:    nil,
-		cfg:    cfg,
-		state:  lib.Service_UNKNOWN,
 	}
-	ss.exe, _ = os.Executable()
-	return ss
-}
-
-func NewServiceInstanceFromMessage(m *pb.ServiceInstance) *ServiceInstance {
-	var f func()
-	if mod, ok := Registry.Modules[m.Module]; ok {
-		if modss, ok := mod.(lib.ModuleSelfService); ok {
-			f = modss.Entry
-		}
-	}
-	si := NewServiceInstance(m.Id, m.Module, f, m.Config)
-	si.SetState(lib.ServiceState(m.State))
+	si.setState((lib.Service_STOP)) // we're obviously stopped right now
+	si.exe, _ = os.Executable()
 	return si
 }
 
 // ID gets the ID string for the service
-func (ss *ServiceInstance) ID() string { return ss.id }
+func (si *ServiceInstance) ID() string { return si.id }
 
-func (ss *ServiceInstance) State() lib.ServiceState {
-	return ss.state
-}
-
-func (ss *ServiceInstance) SetState(state lib.ServiceState) {
-	ss.state = state
-}
+// Module returns the name of the module this is an instance of
+func (si *ServiceInstance) Module() string { return si.module }
 
 // GetState returns the current run state of the service
-// This is only really relevant on a local node
-func (ss *ServiceInstance) GetState() lib.ServiceState {
-	if ss.cmd == nil {
-		return lib.Service_STOP
-	}
-	if ss.cmd.Process != nil {
-		//fmt.Printf("cmd.Process.Pid: %d\n", ss.cmd.Process.Pid)
-		// is it running?
-		p, _ := os.FindProcess(ss.cmd.Process.Pid)
-		if p.Pid < 1 { // we get a negative pid for non-existent
-			return lib.Service_STOP
-		}
-	}
-	return lib.Service_RUN
+func (si *ServiceInstance) GetState() lib.ServiceState {
+	return si.state
 }
 
-// Name returns the service name (i.e. Args[0])
-func (ss *ServiceInstance) Module() string { return ss.module }
-
-// Exe returns the path to the executable for this service (usually self)
-func (ss *ServiceInstance) Exe() string { return ss.exe }
-
-// Cmd returns the current command context, if any
-func (ss *ServiceInstance) Cmd() *exec.Cmd { return ss.cmd }
-
-// SetCmd registers the current command execution context
-func (ss *ServiceInstance) SetCmd(c *exec.Cmd) { ss.cmd = c }
-
-func (ss *ServiceInstance) SetCtl(c chan<- lib.ServiceControl) { ss.ctl = c }
-
-// Entry is *not* part of lib.Service.  This is specifically for linking ServiceInstance
-func (ss *ServiceInstance) Entry() func() { return ss.entry }
-
-// Config returns the current config
-func (ss *ServiceInstance) Config() *any.Any { return ss.cfg }
-
-// UpdateConfig will update the module config, and send an update to it if it's running
-func (ss *ServiceInstance) UpdateConfig(cfg *any.Any) {
-	ss.cfg = cfg
-	if ss.ctl != nil {
-		ss.ctl <- lib.ServiceControl{Command: lib.ServiceControl_UPDATE, Config: ss.cfg}
+// UpdateConfig will send a signal to the running si to check for a config update
+func (si *ServiceInstance) UpdateConfig() {
+	if si.ctl != nil {
+		si.ctl <- lib.ServiceControl{Command: lib.ServiceControl_UPDATE}
 	}
 }
 
-func (ss *ServiceInstance) Message() *pb.ServiceInstance {
-	si := &pb.ServiceInstance{
-		Id:     ss.ID(),
-		Module: ss.Module(),
-		State:  pb.ServiceInstance_ServiceState(ss.State()),
-		Config: ss.Config(),
+// Start will execute the process
+func (si *ServiceInstance) Start() {
+	e := si.start()
+	if e != nil {
+		si.setState(lib.Service_ERROR)
+		return
 	}
-	return si
+	si.setState(lib.Service_RUN)
+	go si.watcher()
 }
 
-func (ss *ServiceInstance) Stop() {
-	ss.SetState(lib.Service_STOP)
-	if ss.ctl != nil {
-		ss.ctl <- lib.ServiceControl{Command: lib.ServiceControl_STOP}
-		ss.cmd.Process.Wait()
+// Stop sends a signal to the running si to stop
+func (si *ServiceInstance) Stop() {
+	if si.ctl != nil {
+		si.ctl <- lib.ServiceControl{Command: lib.ServiceControl_STOP}
 	}
 }
 
-// ModuleExecute does all of the necessary steps to start the service instance
-// This includes getting the API ready
-// It assumes certain things are in the OS environment
-// This may belong somewhere else.
-func ModuleExecute(id, module, sock string) {
+// Watch provides a channel where process state changes will be reported
+func (si *ServiceInstance) Watch(wchan chan<- lib.ServiceState) {
+	si.wchan = wchan
+}
+
+// SetCtl sets the channel to send control message to (to pass through the API)
+func (si *ServiceInstance) SetCtl(ctl chan<- lib.ServiceControl) {
+	si.ctl = ctl
+}
+
+// setState sets the state, but should only be done internally.  This makes sure we notify any watcher
+func (si *ServiceInstance) setState(state lib.ServiceState) {
+	si.state = state
+	if si.wchan != nil {
+		si.wchan <- si.state
+	}
+}
+
+func (si *ServiceInstance) watcher() {
+	e := si.cmd.Wait()
+	if e != nil {
+		si.setState(lib.Service_ERROR)
+		return
+	}
+	si.setState(lib.Service_STOP)
+}
+
+func (si *ServiceInstance) start() (e error) {
+	if si.GetState() == lib.Service_RUN {
+		return fmt.Errorf("cannot start service instance not in stop state")
+	}
+	if _, e = os.Stat(si.exe); os.IsNotExist(e) {
+		return e
+	}
+	// TODO: we should probably do more sanity checks here...
+	si.cmd = exec.Command(si.exe)
+	si.cmd.Args = []string{"[kraken:" + si.ID() + "]"}
+	si.cmd.Stdin = os.Stdin
+	si.cmd.Stdout = os.Stdout
+	si.cmd.Stderr = os.Stderr
+	si.cmd.Env = append(os.Environ(),
+		"KRAKEN_SOCK="+si.sock,
+		"KRAKEN_MODULE="+si.module,
+		"KRAKEN_ID="+si.ID())
+	e = si.cmd.Start()
+	return
+}
+
+// moduleExecute does all of the necessary steps to start the service instance
+// this is the actual entry point for a new module process
+func moduleExecute(id, module, sock string) {
 	m, ok := Registry.Modules[module]
 	if !ok {
 		fmt.Printf("trying to launch non-existent module: %s", module)
@@ -210,36 +204,45 @@ func ModuleExecute(id, module, sock string) {
 		md.SetDiscoveryChan(cc)
 	}
 
-	go func() {
-		for {
-			cmd := <-cc
-			if e != nil {
-				os.Exit(0)
-			}
+	updateConfig := func() {
+		if !config {
+			api.Logf(ERROR, "tried to update config on module with no config")
+			return
+		}
+		// Get a copy of the config
+		n, _ := api.QueryRead(api.Self().String())
+		srv := n.GetService(id)
+		p, e := Registry.Resolve(srv.GetConfig().GetTypeUrl())
+		if e != nil {
+			api.Logf(ERROR, "resolve config error: %v\n", e)
+			return
+		}
+		e = ptypes.UnmarshalAny(srv.GetConfig(), p)
+		if e != nil {
+			api.Logf(ERROR, "unmarshal config failure: %v\n", e)
+			return
+		}
+		mc.UpdateConfig(p)
+	}
+
+	if config {
+		updateConfig()
+	}
+	go mss.Entry()
+
+	for {
+		select {
+		case cmd := <-cc:
 			switch cmd.Command {
 			case lib.ServiceControl_STOP:
-				os.Exit(0)
+				api.Logf(NOTICE, "stopping")
+				mss.Stop()
 				break
 			case lib.ServiceControl_UPDATE:
-				if !config {
-					api.Logf(ERROR, "tried to update config on module with no config")
-					break
-				}
-				p, e := Registry.Resolve(cmd.Config.GetTypeUrl())
-				if e != nil {
-					api.Logf(ERROR, "resolve config error: %v\n", e)
-					break
-				}
-				e = ptypes.UnmarshalAny(cmd.Config, p)
-				if e != nil {
-					api.Logf(ERROR, "unmarshal config failure: %v\n", e)
-					break
-				}
-				mc.UpdateConfig(p)
+				updateConfig()
 				break
 			default:
 			}
 		}
-	}()
-	mss.Entry()
+	}
 }

--- a/core/ServiceInstance.go
+++ b/core/ServiceInstance.go
@@ -231,7 +231,7 @@ func ModuleExecute(id, module, sock string) {
 		srv := n.GetService(id)
 		p, e := Registry.Resolve(srv.GetConfig().GetTypeUrl())
 		if e != nil {
-			api.Logf(ERROR, "resolve config error: %v\n", e)
+			api.Logf(ERROR, "resolve config error (%s): %v\n", srv.GetConfig().GetTypeUrl(), e)
 			return
 		}
 		e = ptypes.UnmarshalAny(srv.GetConfig(), p)

--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -137,8 +137,19 @@ func (sm *ServiceManager) GetService(si string) lib.ServiceInstance {
 
 func (sm *ServiceManager) processStateChange(v *StateChangeEvent) {
 	// extract SI
-	us := lib.URLToSlice(v.URL)
-	si := us[1]
+	_, url := lib.NodeURLSplit(v.URL)
+	us := lib.URLToSlice(url)
+	si := ""
+	// this makes sure we don't get tripped up by leading slashes
+	for i := range us {
+		if us[i] == "Services" {
+			si = us[i+1]
+		}
+	}
+	if si == "" {
+		sm.log.Logf(lib.LLDEBUG, "failed to parse URL for /Services state change: %s", v.URL)
+		return
+	}
 	sm.syncService(si)
 }
 

--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -10,13 +10,11 @@
 package core
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"time"
+	"reflect"
+	"regexp"
+	"sync"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
+	pb "github.com/hpc/kraken/core/proto"
 	"github.com/hpc/kraken/lib"
 )
 
@@ -24,193 +22,181 @@ import (
 // ServiceManager Object /
 /////////////////////////
 
-var _ lib.ServiceManager = (*ServiceManager)(nil)
-
 type ServiceManager struct {
-	srv  map[string]lib.ServiceInstance
-	sock string
+	srv    map[string]lib.ServiceInstance // map of si IDs to ServiceInstances
+	mutex  *sync.Mutex
+	sock   string // socket that we use for API comms
+	sclist lib.EventListener
+	echan  chan lib.Event
+	wchan  chan lib.ServiceInstanceUpdate
+	ctx    Context
+	log    lib.Logger
 }
 
-func NewServiceManager(sock string) *ServiceManager {
+func NewServiceManager(ctx Context, sock string) *ServiceManager {
 	sm := &ServiceManager{
-		srv:  make(map[string]lib.ServiceInstance),
-		sock: sock,
+		srv:   make(map[string]lib.ServiceInstance),
+		mutex: &sync.Mutex{},
+		sock:  sock,
+		echan: make(chan lib.Event),
+		wchan: make(chan lib.ServiceInstanceUpdate),
+		ctx:   ctx,
+		log:   &ctx.Logger,
 	}
+	sm.log.SetModule("ServiceManager")
 	return sm
 }
 
-func (sm *ServiceManager) AddService(s lib.ServiceInstance) (e error) {
-	if _, ok := sm.srv[s.ID()]; ok {
-		return fmt.Errorf("service by this ID already exists: %s", s.ID())
-	}
-	sm.srv[s.ID()] = s
-	return
-}
+func (sm *ServiceManager) Run(ready chan<- interface{}) {
+	// subscribe to STATE_CHANGE events for "/Services"
+	smurl := regexp.MustCompile(`^\/?Services\/`)
+	sm.sclist = NewEventListener(
+		"ServiceManager",
+		lib.Event_STATE_CHANGE,
+		func(v lib.Event) bool {
+			node, url := lib.NodeURLSplit(v.URL())
+			if !NewNodeID(node).Equal(sm.ctx.Self) {
+				return false
+			}
+			if smurl.MatchString(url) {
+				return true
+			}
+			return false
+		},
+		func(v lib.Event) error { return ChanSender(v, sm.echan) },
+	)
+	sm.ctx.SubChan <- sm.sclist
 
-// AddServiceByURL adds a service that corresponds to a know module URL
-func (sm *ServiceManager) AddServiceByModule(id, module string, cfg *any.Any) (e error) {
-	if m, ok := Registry.Modules[module]; ok {
-		if s, ok := m.(lib.ModuleSelfService); ok {
-			// TODO: it would be easy to expand this so there could be multiple instances of the same service
-			return sm.AddService(NewServiceInstance(id, s.Name(), s.Entry, cfg))
+	// initialize service instances
+	for m := range Registry.ServiceInstances {
+		for _, si := range Registry.ServiceInstances[m] {
+			sm.log.Logf(lib.LLINFO, "adding service: %s", si.ID())
+			sm.AddService(si)
 		}
-		return fmt.Errorf("module is not runnable: %s", module)
 	}
-	return fmt.Errorf("module not found by url: %s", module)
-}
 
-func (sm *ServiceManager) DelService(id string) (e error) {
-	if s, ok := sm.srv[id]; ok {
-		if s.State() == lib.Service_RUN {
-			return fmt.Errorf("service is running, stop before deleting: %s", id)
+	go func() {
+		sm.log.Logf(lib.LLDEBUG, "starting initial service sync")
+		for _, si := range sm.srv {
+			sm.syncService(si.ID())
 		}
-		delete(sm.srv, id)
+	}()
+
+	// ready to go
+	ready <- nil
+
+	// main listening loop
+	for {
+		select {
+		case v := <-sm.echan:
+			// state change for services
+			sm.log.Logf(lib.LLDDEBUG, "processing state change event: %s", v.URL())
+			go sm.processStateChange(v.Data().(*StateChangeEvent))
+		case su := <-sm.wchan:
+			// si changed process state
+			sm.log.Logf(lib.LLDDEBUG, "processing SI state update: %s -> %+v", su.ID, su.State)
+			go sm.processUpdate(su)
+		}
 	}
-	return fmt.Errorf("cannot delete non-existent service: %s", id)
 }
 
-func (sm *ServiceManager) Service(id string) (si lib.ServiceInstance) {
-	var ok bool
-	if si, ok = sm.srv[id]; ok {
-		return
+func (sm *ServiceManager) AddService(si lib.ServiceInstance) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if _, ok := sm.srv[si.ID()]; ok {
+		sm.log.Logf(lib.LLERROR, "tried to add service that already exists: %s", si.ID())
+	}
+	sm.srv[si.ID()] = si
+	si.Watch(sm.wchan)
+	si.SetSock(sm.sock)
+}
+
+func (sm *ServiceManager) DelService(si string) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if si, ok := sm.srv[si]; ok {
+		si.Watch(nil) // we don't want to watch this anymore
+		si.SetSock("")
+		delete(sm.srv, si.ID())
+	}
+}
+
+func (sm *ServiceManager) GetService(si string) lib.ServiceInstance {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if si, ok := sm.srv[si]; ok {
+		return si
 	}
 	return nil
 }
 
-func (sm *ServiceManager) RunService(id string) (e error) {
-	if s, ok := sm.srv[id]; ok {
-		if s.State() != lib.Service_RUN {
-			if e = sm.start(s); e == nil {
-				s.SetState(lib.Service_RUN)
-			}
-			return
-		}
-		return fmt.Errorf("service is in state, %d, cannot start", s.State())
-	}
-	return fmt.Errorf("cannot run non-existent service: %s", id)
+func (sm *ServiceManager) processStateChange(v *StateChangeEvent) {
+	// extract SI
+	us := lib.URLToSlice(v.URL)
+	si := us[1]
+	sm.syncService(si)
 }
 
-func (sm *ServiceManager) StopService(id string) (e error) {
-	if s, ok := sm.srv[id]; ok {
-		if s.State() == lib.Service_RUN {
-			s.Stop()
-			s.SetCmd(nil)
-			return
-		}
-		return fmt.Errorf("service is in state, %d, cannot stop", s.State())
+func (sm *ServiceManager) processUpdate(su lib.ServiceInstanceUpdate) {
+	// set the state in the SDE
+	switch su.State {
+	case lib.Service_STOP:
+		sm.setServiceStateDsc(su.ID, pb.ServiceInstance_STOP)
+	case lib.Service_RUN:
+		// this is actually pb state INIT; it's up to
+		sm.setServiceStateDsc(su.ID, pb.ServiceInstance_INIT)
+	case lib.Service_ERROR:
+		sm.setServiceStateDsc(su.ID, pb.ServiceInstance_ERROR)
 	}
-	return fmt.Errorf("cannot stop non-existent service: %s", id)
 }
 
-func (sm *ServiceManager) GetServiceIDs() []string {
-	r := []string{}
-	for k := range sm.srv {
-		r = append(r, k)
-	}
-	return r
-}
-
-func (sm *ServiceManager) syncState(s lib.ServiceInstance, state lib.ServiceState) lib.ServiceState {
-	r := lib.Service_UNKNOWN
-	if s.GetState() != state {
-		switch state {
-		case lib.Service_RUN:
-			e := sm.RunService(s.ID())
-			if e != nil {
-			}
-			r = lib.Service_INIT
-			break
-		case lib.Service_STOP:
-			s.Stop() // we'll have 3 seconds to gracefully stop
-			go func() {
-				time.Sleep(3 * time.Second)
-				sm.kill(s)
-			}()
-			r = lib.Service_STOP
-			break
-		default: // don't do anything
-		}
-	}
-	return r
-}
-
-// SyncNode synchronizes service info between the state store of self and the service manager
-// It reports the current discoverable state of all services
-// NOTE: This is probablly very inefficient
-// the returned map is what we have "discovered"
-func (sm *ServiceManager) SyncNode(n lib.Node) map[string]lib.ServiceState {
-	r := make(map[string]lib.ServiceState)
-	sids := sm.GetServiceIDs()
-	for _, srv := range n.GetServices() {
-		for i, s := range sids {
-			if s == srv.ID() {
-				sids = append(sids[:i], sids[i+1:]...)
-			}
-		}
-		if s, ok := sm.srv[srv.ID()]; ok {
-			if !proto.Equal(s.Config(), srv.Config()) {
-				s.UpdateConfig(srv.Config())
-			}
-			if ss := sm.syncState(s, srv.State()); ss != lib.Service_UNKNOWN {
-				r[srv.ID()] = ss
-			}
-		} else {
-			e := sm.AddServiceByModule(srv.ID(), srv.Module(), srv.Config())
-			if e != nil {
-				return r
-			}
-			if ss := sm.syncState(sm.srv[srv.ID()], srv.State()); ss != lib.Service_UNKNOWN {
-				r[srv.ID()] = ss
-			}
-		}
-	}
-	// sids is now a list of services we're not supposed to have anymore
-	for _, id := range sids {
-		sm.srv[id].Stop()
-		go func() {
-			time.Sleep(3 * time.Second)
-			sm.kill(sm.srv[id])
-		}()
-		sm.DelService(id)
-	}
-	return r
-}
-
-func (sm *ServiceManager) start(s lib.ServiceInstance) (e error) {
-	if s.State() == lib.Service_RUN {
-		return fmt.Errorf("service is already running")
-	}
-	if _, e = os.Stat(s.Exe()); os.IsNotExist(e) {
-		return e
-	}
-	// TODO: we should probably do more sanity checks here...
-	cmd := exec.Command(s.Exe())
-	cmd.Args = []string{"[kraken:" + s.ID() + "]"}
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(),
-		"KRAKEN_SOCK="+sm.sock,
-		"KRAKEN_MODULE="+s.Module(),
-		"KRAKEN_ID="+s.ID())
-	e = cmd.Start()
-	s.SetCmd(cmd)
-	s.SetState(lib.Service_RUN)
-	return
-}
-
-func (sm *ServiceManager) kill(s lib.ServiceInstance) (e error) {
-	cmd := s.Cmd()
-	if cmd == nil || cmd.Process == nil {
+// syncService is what actually does most of the work.  It compares cfg to dsc and decides what to do
+func (sm *ServiceManager) syncService(si string) {
+	srv := sm.GetService(si)
+	if srv == nil {
+		sm.log.Logf(lib.LLERROR, "tried to sync non-existent service: %s", si)
 		return
 	}
-	/*
-		if s.State() != lib.Service_RUN {
-			return fmt.Errorf("cannot kill a process that isn't running")
+	c := sm.getServiceStateCfg(si)
+	d := sm.getServiceStateDsc(si)
+
+	if c == d { // nothing to do
+		sm.log.Logf(lib.LLDDEBUG, "service already synchronized: %s (%+v)", si, c)
+		return
+	}
+	if d == pb.ServiceInstance_ERROR { // don't clear errors
+		return
+	}
+	switch c {
+	case pb.ServiceInstance_RUN: // we're supposed to be running
+		if d != pb.ServiceInstance_INIT { // did we already try to start?
+			srv.Start() // startup
 		}
-	*/
-	s.SetState(lib.Service_STOP)
-	cmd.Process.Kill()
-	cmd.Process.Wait()
-	return cmd.Process.Release()
+	case pb.ServiceInstance_STOP: // we're supposed to be stopped
+		srv.Stop() // stop
+	}
+}
+
+// Some helper functions...
+
+func (sm *ServiceManager) getServiceStateCfg(si string) pb.ServiceInstance_ServiceState {
+	n, _ := sm.ctx.Query.Read(sm.ctx.Self)
+	v, _ := n.GetValue(sm.stateURL(si))
+	return pb.ServiceInstance_ServiceState(v.Int())
+}
+
+func (sm *ServiceManager) getServiceStateDsc(si string) pb.ServiceInstance_ServiceState {
+	n, _ := sm.ctx.Query.ReadDsc(sm.ctx.Self)
+	v, _ := n.GetValue(sm.stateURL(si))
+	return pb.ServiceInstance_ServiceState(v.Int())
+}
+
+func (sm *ServiceManager) setServiceStateDsc(si string, state pb.ServiceInstance_ServiceState) {
+	n, _ := sm.ctx.Query.ReadDsc(sm.ctx.Self)
+	n.SetValue(sm.stateURL(si), reflect.ValueOf(state))
+	sm.ctx.Query.UpdateDsc(n)
+}
+
+func (sm *ServiceManager) stateURL(si string) string {
+	return lib.URLPush(lib.URLPush("/Services", si), "State")
 }

--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -177,7 +177,7 @@ func (n *StateDifferenceEngine) SetValue(url string, v reflect.Value) (r reflect
 	if e != nil {
 		n.Logf(ERROR, "failed to set value (cfg): %v", e)
 	}
-	go n.EmitOne(NewStateChangeEvent(StateChange_CFG_UPDATE, url, reflect.ValueOf(r)))
+	go n.EmitOne(NewStateChangeEvent(StateChange_CFG_UPDATE, url, r))
 	return
 }
 
@@ -194,7 +194,7 @@ func (n *StateDifferenceEngine) SetValueDsc(url string, v reflect.Value) (r refl
 	if e != nil {
 		n.Logf(ERROR, "failed to set value (dsc): %v", e)
 	}
-	go n.EmitOne(NewStateChangeEvent(StateChange_UPDATE, url, reflect.ValueOf(r)))
+	go n.EmitOne(NewStateChangeEvent(StateChange_UPDATE, url, r))
 	return
 }
 

--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -167,14 +167,15 @@ func NewStateSyncEngine(ctx Context) *StateSyncEngine {
 
 // implement lib.ServiceInstance
 // this is a bit of a hack
-func (sse *StateSyncEngine) ID() string                       { return sse.Name() }
-func (sse *StateSyncEngine) Module() string                   { return sse.Name() }
-func (sse *StateSyncEngine) Start()                           {} //NOP
-func (sse *StateSyncEngine) Stop()                            {} //NOP
-func (sse *StateSyncEngine) GetState() lib.ServiceState       { return lib.Service_RUN }
-func (sse *StateSyncEngine) UpdateConfig()                    {} //NOP
-func (sse *StateSyncEngine) Watch(chan<- lib.ServiceState)    {} //NOP
-func (sse *StateSyncEngine) SetCtl(chan<- lib.ServiceControl) {} //NOP
+func (sse *StateSyncEngine) ID() string                             { return sse.Name() }
+func (sse *StateSyncEngine) Module() string                         { return sse.Name() }
+func (sse *StateSyncEngine) Start()                                 {} //NOP
+func (sse *StateSyncEngine) Stop()                                  {} //NOP
+func (sse *StateSyncEngine) GetState() lib.ServiceState             { return lib.Service_RUN }
+func (sse *StateSyncEngine) UpdateConfig()                          {} //NOP
+func (sse *StateSyncEngine) Watch(chan<- lib.ServiceInstanceUpdate) {} //NOP
+func (sse *StateSyncEngine) SetCtl(chan<- lib.ServiceControl)       {} //NOP
+func (sse *StateSyncEngine) SetSock(string)                         {} //NOP
 
 // implement lib.Module
 func (*StateSyncEngine) Name() string { return "sse" }

--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net"
-	"os/exec"
 	"reflect"
 	"strconv"
 	"sync"
@@ -28,7 +27,6 @@ import (
 	"github.com/hpc/kraken/lib"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -168,22 +166,15 @@ func NewStateSyncEngine(ctx Context) *StateSyncEngine {
 }
 
 // implement lib.ServiceInstance
-// this is a little artificial, but it's a special case
-// many of these would never becaused because it's not actually managed
-// by ServiceManager
-func (sse *StateSyncEngine) ID() string                   { return sse.Name() }
-func (*StateSyncEngine) State() lib.ServiceState          { return lib.Service_RUN }
-func (*StateSyncEngine) SetState(lib.ServiceState)        {}
-func (*StateSyncEngine) GetState() lib.ServiceState       { return lib.Service_RUN }
-func (sse *StateSyncEngine) Module() string               { return sse.Name() }
-func (*StateSyncEngine) Exe() string                      { return "" }
-func (*StateSyncEngine) Cmd() *exec.Cmd                   { return nil }
-func (*StateSyncEngine) SetCmd(*exec.Cmd)                 {}
-func (*StateSyncEngine) Stop()                            {}
-func (*StateSyncEngine) SetCtl(chan<- lib.ServiceControl) {}
-func (*StateSyncEngine) Config() *any.Any                 { return nil }
-func (*StateSyncEngine) UpdateConfig(*any.Any)            {}
-func (*StateSyncEngine) Message() *pb.ServiceInstance     { return nil }
+// this is a bit of a hack
+func (sse *StateSyncEngine) ID() string                       { return sse.Name() }
+func (sse *StateSyncEngine) Module() string                   { return sse.Name() }
+func (sse *StateSyncEngine) Start()                           {} //NOP
+func (sse *StateSyncEngine) Stop()                            {} //NOP
+func (sse *StateSyncEngine) GetState() lib.ServiceState       { return lib.Service_RUN }
+func (sse *StateSyncEngine) UpdateConfig()                    {} //NOP
+func (sse *StateSyncEngine) Watch(chan<- lib.ServiceState)    {} //NOP
+func (sse *StateSyncEngine) SetCtl(chan<- lib.ServiceControl) {} //NOP
 
 // implement lib.Module
 func (*StateSyncEngine) Name() string { return "sse" }

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -103,6 +103,6 @@ func main() {
 
 	// wait forever
 	for {
-
+		select {}
 	}
 }

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -16,16 +16,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 
 	"github.com/hpc/kraken/core"
 	"github.com/hpc/kraken/lib"
 
 	_ "net/http/pprof"
 
-	"github.com/golang/protobuf/ptypes"
-	pb "github.com/hpc/kraken/core/proto"
-	pbr "github.com/hpc/kraken/modules/restapi/proto"
+	cpb "github.com/hpc/kraken/core/proto"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -71,134 +68,22 @@ func main() {
 		return
 	}
 
-	muts := make(map[string]lib.StateMutation)
-	discs := make(map[string]map[string]reflect.Value)
-
 	k := core.NewKraken(*idstr, *ip, parents, lib.LoggerLevel(*llevel))
-
-	// inject service instances
-	// & declare mutations/discoveries for each
-	// note: this can be overridden by a parent
-	for i := range core.Registry.ServiceInstances {
-		for _, si := range core.Registry.ServiceInstances[i] {
-
-			stateStr := lib.URLPush(lib.URLPush("/Services", si.ID()), "State")
-
-			makeMut := func(a pb.ServiceInstance_ServiceState, b pb.ServiceInstance_ServiceState) lib.StateMutation {
-				return core.NewStateMutation(
-					map[string][2]reflect.Value{
-						stateStr: [2]reflect.Value{
-							reflect.ValueOf(a),
-							reflect.ValueOf(b),
-						},
-					},
-					map[string]reflect.Value{
-						"/RunState": reflect.ValueOf(pb.Node_SYNC),
-						"/PhysState": reflect.ValueOf(pb.Node_POWER_ON),
-					},
-					map[string]reflect.Value{},
-					lib.StateMutationContext_SELF,
-					0,
-					[3]string{},
-				)
-			}
-			mutUrls := make(map[string]bool)
-			for i := range core.Registry.Mutations {
-				for _, m := range core.Registry.Mutations[i] {
-					for u := range m.Mutates() {
-						mutUrls[u] = true
-					}
-					for u := range m.Requires() {
-						mutUrls[u] = true
-					}
-					for u := range m.Excludes() {
-						mutUrls[u] = true
-					}
-				}
-			}
-			if _, ok := mutUrls[stateStr]; ok {
-				muts[si.ID()+"UkToInit"] = makeMut(pb.ServiceInstance_UNKNOWN, pb.ServiceInstance_INIT)
-				muts[si.ID()+"StopToInit"] = makeMut(pb.ServiceInstance_STOP, pb.ServiceInstance_INIT)
-				muts[si.ID()+"InitToRun"] = makeMut(pb.ServiceInstance_INIT, pb.ServiceInstance_RUN)
-				muts[si.ID()+"RunToStop"] = makeMut(pb.ServiceInstance_RUN, pb.ServiceInstance_STOP)
-			}
-			discs[stateStr] = map[string]reflect.Value{
-				"Stop": reflect.ValueOf(pb.ServiceInstance_STOP),
-				"Init": reflect.ValueOf(pb.ServiceInstance_INIT),
-				"Run":  reflect.ValueOf(pb.ServiceInstance_RUN),
-			}
-		}
-	}
-	core.Registry.RegisterMutations(k, muts)
-	core.Registry.RegisterDiscoverable(k, discs)
-	stateToVID := map[lib.ServiceState]string{
-		lib.Service_UNKNOWN: "Unknown",
-		lib.Service_STOP:    "Stop",
-		lib.Service_RUN:     "Run",
-	}
-	emitDiscoveries := func(ds map[string]lib.ServiceState) {
-		vs := []lib.Event{}
-		for d := range ds {
-			stateStr := lib.URLPush(lib.URLPush("/Services", d), "State")
-			url := lib.NodeURLJoin(k.Ctx.Self.String(), stateStr)
-			v := core.NewEvent(
-				lib.Event_DISCOVERY,
-				url,
-				&core.DiscoveryEvent{
-					ID:  k.ID(),
-					URL:     url,
-					ValueID: stateToVID[ds[d]],
-				},
-			)
-			vs = append(vs, v)
-		}
-		k.Emit(vs)
-	}
-
 	k.Release()
+
 	qe := core.NewQueryEngine(k.Sde.QueryChan(), k.Sme.QueryChan())
 	// we'll modify ourselves a bit to get running
 	self, _ := qe.Read(k.Ctx.Self)
 
 	// if we're full-state, we start restapi automatically
 	if len(parents) == 0 {
-		restapi := self.GetService("restapi")
-		cfg := &pbr.RestAPIConfig{
-			Addr: *ipapi,
-			Port: 3141,
-		}
-		any, _ := ptypes.MarshalAny(cfg)
-		restapi.SetState(lib.Service_RUN)
-		restapi.UpdateConfig(any)
+		self.SetValues(map[string]reflect.Value{
+			"/Services/restapi/State":       reflect.ValueOf(cpb.ServiceInstance_RUN),
+			"/Services/restapi/Config/Addr": reflect.ValueOf(*ipapi),
+			"/Services/restapi/Config/Port": reflect.ValueOf(3141),
+		})
 	}
 	qe.Update(self)
-	self, _ = qe.Read(k.Ctx.Self)
-	emitDiscoveries(k.Ctx.Services.SyncNode(self))
-
-	echan := make(chan lib.Event)
-	sclist_re, _ := regexp.Compile(".*Services.*")
-	// OK, we need to manage services now
-	// We make an event listener for service changes for us
-	sclist := core.NewEventListener(
-		"Kraken",
-		lib.Event_STATE_CHANGE,
-		func(v lib.Event) bool {
-			node, url := lib.NodeURLSplit(v.URL())
-			if !core.NewNodeID(node).Equal(k.Ctx.Self) {
-				// we only care about ourself
-				return false
-			}
-			if sclist_re.Match([]byte(url)) {
-				return true
-			}
-			return false
-		},
-		func(v lib.Event) error {
-			return core.ChanSender(v, echan)
-		})
-
-	// subscribe our listener
-	k.Ctx.SubChan <- sclist
 
 	// Thaw if full state
 	if len(parents) == 0 {
@@ -207,19 +92,6 @@ func main() {
 
 	// wait forever
 	for {
-		select {
-		case v := <-echan:
-			_, url := lib.NodeURLSplit(v.URL())
-			if v.Type() == lib.Event_STATE_CHANGE && sclist_re.Match([]byte(url)) {
-				k.Logf(lib.LLDEBUG, "got event, need to update services: %v\n", v)
-				me, e := qe.Read(k.Ctx.Self)
-				if e != nil {
-					k.Logf(lib.LLERROR, "I seem to have forgotten myself!")
-					panic("amnesia")
-				}
-				emitDiscoveries(k.Ctx.Services.SyncNode(me))
-			}
-			break
-		}
+
 	}
 }

--- a/lib/types.go
+++ b/lib/types.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	proto "github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	pb "github.com/hpc/kraken/core/proto"
 )
 
@@ -497,17 +496,10 @@ type ServiceInstance interface {
 
 // A ServiceManager handles the lifecycle of external services
 type ServiceManager interface {
-	AddService(ServiceInstance) error
-	AddServiceByModule(id string, name string, cfg *any.Any) error
-	DelService(name string) error
-	GetServiceIDs() []string
-
-	Service(id string) ServiceInstance // returns a service by ID, nil if not found
-
-	RunService(id string) error
-	StopService(id string) error
-
-	SyncNode(n Node) map[string]ServiceState
+	AddService(ServiceInstance)
+	DelService(string)
+	GetService(string) ServiceInstance
+	Run(chan<- interface{})
 }
 
 /*

--- a/lib/types.go
+++ b/lib/types.go
@@ -475,15 +475,24 @@ const (
 type ServiceControl struct {
 	Command ServiceControl_Command
 }
+
+// ServiceInstanceUpdate is sent to watchers
+type ServiceInstanceUpdate struct {
+	ID    string
+	State ServiceState
+	Error error
+}
+
 type ServiceInstance interface {
-	ID() string                   // Get ID for service instance
-	Module() string               // Name of module this is an instance of
-	GetState() ServiceState       // Return the current process state
-	UpdateConfig()                // Tell process to update its config
-	Start()                       // Tell process to start
-	Stop()                        // Tell process to stop
-	Watch(chan<- ServiceState)    // Tell process to report state changes over this chan
-	SetCtl(chan<- ServiceControl) // Where to send service control messages
+	ID() string                         // Get ID for service instance
+	Module() string                     // Name of module this is an instance of
+	GetState() ServiceState             // Return the current process state
+	UpdateConfig()                      // Tell process to update its config
+	Start()                             // Tell process to start
+	Stop()                              // Tell process to stop
+	Watch(chan<- ServiceInstanceUpdate) // Tell process to report state changes over this chan
+	SetCtl(chan<- ServiceControl)       // Where to send service control messages
+	SetSock(string)                     // Set the path to the API socket
 }
 
 // A ServiceManager handles the lifecycle of external services

--- a/lib/types.go
+++ b/lib/types.go
@@ -10,7 +10,6 @@
 package lib
 
 import (
-	"os/exec"
 	"reflect"
 	"time"
 
@@ -82,11 +81,11 @@ type Node interface {
 	DelExtension(url string)
 	HasExtension(url string) bool
 
-	AddService(ServiceInstance) error
+	AddService(*pb.ServiceInstance) error
 	DelService(id string)
-	GetService(id string) ServiceInstance
+	GetService(id string) *pb.ServiceInstance
 	GetServiceIDs() []string
-	GetServices() []ServiceInstance
+	GetServices() []*pb.ServiceInstance
 	HasService(id string) bool
 
 	Diff(node Node, prefix string) (diff []string, e error)
@@ -475,22 +474,16 @@ const (
 
 type ServiceControl struct {
 	Command ServiceControl_Command
-	Config  *any.Any
 }
 type ServiceInstance interface {
-	ID() string
-	State() ServiceState
-	SetState(ServiceState)
-	GetState() ServiceState // GetState tries to discover the real state on a node running the service
-	Module() string
-	Exe() string // services take two arguments - connect string, and instance ID
-	Cmd() *exec.Cmd
-	SetCmd(*exec.Cmd)
-	Stop()
-	SetCtl(chan<- ServiceControl)
-	Config() *any.Any
-	UpdateConfig(*any.Any)
-	Message() *pb.ServiceInstance
+	ID() string                   // Get ID for service instance
+	Module() string               // Name of module this is an instance of
+	GetState() ServiceState       // Return the current process state
+	UpdateConfig()                // Tell process to update its config
+	Start()                       // Tell process to start
+	Stop()                        // Tell process to stop
+	Watch(chan<- ServiceState)    // Tell process to report state changes over this chan
+	SetCtl(chan<- ServiceControl) // Where to send service control messages
 }
 
 // A ServiceManager handles the lifecycle of external services

--- a/modules/cpuburn/cpuburn.go
+++ b/modules/cpuburn/cpuburn.go
@@ -291,7 +291,7 @@ func kernelLucasLehmer() {
 
 func init() {
 	module := &CPUBurn{}
-	si := core.NewServiceInstance("cpuburn", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("cpuburn", module.Name(), module.Entry)
 	core.Registry.RegisterModule(module)
 	core.Registry.RegisterServiceInstance(module, map[string]lib.ServiceInstance{si.ID(): si})
 	core.Registry.RegisterDiscoverable(si, map[string]map[string]reflect.Value{

--- a/modules/dummy/dummy.go
+++ b/modules/dummy/dummy.go
@@ -223,7 +223,7 @@ func init() {
 	module := &Dummy{}
 	core.Registry.RegisterModule(module)
 	pdsc := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("dummy", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("dummy", module.Name(), module.Entry)
 
 	for k, v := range muts {
 		pdsc[v[1]] = reflect.ValueOf(v[1])
@@ -247,7 +247,6 @@ func init() {
 	discovers["/Platform"] = pdsc
 	discovers["/Services/dummy/State"] = map[string]reflect.Value{
 		"Run": reflect.ValueOf(corepb.ServiceInstance_RUN)}
-	si.SetState(lib.Service_STOP)
 	core.Registry.RegisterDiscoverable(si, discovers)
 	core.Registry.RegisterMutations(si, mutations)
 	core.Registry.RegisterServiceInstance(module, map[string]lib.ServiceInstance{si.ID(): si})

--- a/modules/hostfrequencyscaling/hostfrequencyscaling.go
+++ b/modules/hostfrequencyscaling/hostfrequencyscaling.go
@@ -321,7 +321,7 @@ func init() {
 	discovers := make(map[string]map[string]reflect.Value)
 	hostFreqScalerDiscs := make(map[string]reflect.Value)
 	hostThermDiscs := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("hostfrequencyscaling", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("hostfrequencyscaling", module.Name(), module.Entry)
 
 	hostThermDiscs[hostthpb.HostThermal_CPU_TEMP_NONE.String()] = reflect.ValueOf(hostthpb.HostThermal_CPU_TEMP_NONE)
 	hostThermDiscs[hostthpb.HostThermal_CPU_TEMP_NORMAL.String()] = reflect.ValueOf(hostthpb.HostThermal_CPU_TEMP_NORMAL)

--- a/modules/hostthermaldiscovery/hostthermaldiscovery.go
+++ b/modules/hostthermaldiscovery/hostthermaldiscovery.go
@@ -136,7 +136,7 @@ func init() {
 	discovers[ModuleStateURL] = map[string]reflect.Value{
 		"RUN": reflect.ValueOf(cpb.ServiceInstance_RUN)}
 
-	si := core.NewServiceInstance("hostthermaldiscovery", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("hostthermaldiscovery", module.Name(), module.Entry)
 
 	// Register it all
 	core.Registry.RegisterModule(module)

--- a/modules/pipower/pipower.go
+++ b/modules/pipower/pipower.go
@@ -387,7 +387,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	drstate := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("pipower", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("pipower", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/pipxe/pipxe.go
+++ b/modules/pipxe/pipxe.go
@@ -333,7 +333,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	dpxe := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("pipxe", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("pipxe", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/powermancontrol/powermancontrol.go
+++ b/modules/powermancontrol/powermancontrol.go
@@ -407,7 +407,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	drstate := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("powermancontrol", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("powermancontrol", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/pxe/pxe.go
+++ b/modules/pxe/pxe.go
@@ -312,7 +312,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	dpxe := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("pxe", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("pxe", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/restapi/restapi.go
+++ b/modules/restapi/restapi.go
@@ -159,8 +159,8 @@ func (r *RestAPI) webSocketRedirect(w http.ResponseWriter, req *http.Request) {
 	services := nself.GetServices()
 	found := false
 	for _, srv := range services {
-		if srv.Module() == "github.com/hpc/kraken/modules/websocket" {
-			if srv.State() == lib.Service_RUN {
+		if srv.GetModule() == "github.com/hpc/kraken/modules/websocket" {
+			if srv.GetState() == cpb.ServiceInstance_RUN {
 				found = true
 			}
 		}
@@ -689,7 +689,6 @@ func init() {
 		"restapi",
 		module.Name(),
 		module.Entry,
-		nil,
 	)
 	core.Registry.RegisterServiceInstance(module, map[string]lib.ServiceInstance{
 		si.ID(): si,

--- a/modules/rfpipower/RFPiPower.go
+++ b/modules/rfpipower/RFPiPower.go
@@ -397,7 +397,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	drstate := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("rfpipower", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("rfpipower", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/rfthermaldiscovery/rfthermaldiscovery.go
+++ b/modules/rfthermaldiscovery/rfthermaldiscovery.go
@@ -137,7 +137,7 @@ func init() {
 	discovers[ModuleStateURL] = map[string]reflect.Value{
 		"RUN": reflect.ValueOf(cpb.ServiceInstance_RUN)}
 
-	si := core.NewServiceInstance("rfthermaldiscovery", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("rfthermaldiscovery", module.Name(), module.Entry)
 
 	// Register it all
 	core.Registry.RegisterModule(module)

--- a/modules/vboxmanage/vboxmanage.go
+++ b/modules/vboxmanage/vboxmanage.go
@@ -492,7 +492,7 @@ func init() {
 	mutations := make(map[string]lib.StateMutation)
 	discovers := make(map[string]map[string]reflect.Value)
 	drstate := make(map[string]reflect.Value)
-	si := core.NewServiceInstance("vboxmanage", module.Name(), module.Entry, nil)
+	si := core.NewServiceInstance("vboxmanage", module.Name(), module.Entry)
 
 	for m := range muts {
 		dur, _ := time.ParseDuration(muts[m].timeout)

--- a/modules/vboxmanage/vboxmanage.go
+++ b/modules/vboxmanage/vboxmanage.go
@@ -126,7 +126,7 @@ func (*VBM) NewConfig() proto.Message {
 		Servers: map[string]*pb.VBMServer{
 			"vbm": {
 				Name: "vbm",
-				Ip:   "localhost",
+				Ip:   "vboxmanage.local",
 				Port: 8269,
 			},
 		},
@@ -513,6 +513,7 @@ func init() {
 	}
 	discovers["/PhysState"] = drstate
 	discovers["/PhysState"]["PHYS_UNKNOWN"] = reflect.ValueOf(cpb.Node_PHYS_UNKNOWN)
+	discovers["/PhysState"]["PHYS_HANG"] = reflect.ValueOf(cpb.Node_PHYS_HANG)
 	discovers["/RunState"] = map[string]reflect.Value{
 		"RUN_UK": reflect.ValueOf(cpb.Node_UNKNOWN),
 	}

--- a/modules/websocket/websocket.go
+++ b/modules/websocket/websocket.go
@@ -287,7 +287,6 @@ func init() {
 		"websocket",
 		module.Name(),
 		module.Entry,
-		nil,
 	)
 
 	discovers := make(map[string]map[string]reflect.Value)


### PR DESCRIPTION
For SI autoloading to work, we need to have sensible default configs for modules.  This tells vboxmanage to assume the API lives at hostname `vboxmanage.local`, which can easily be set in `/etc/hosts`.  It also fixes an issue where PHYS_HANG was not declared as a discoverable.