### PR TITLE
Change the INITtoSYNC failto id to "sse"

### DIFF
--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -851,7 +851,7 @@ func init() {
 			map[string]reflect.Value{},
 			lib.StateMutationContext_CHILD,
 			time.Second*90, // FIXME: don't hardcode values
-			[3]string{"core", "/PhysState", "HANG"},
+			[3]string{"sse", "/PhysState", "HANG"},
 		),
 	}
 	Registry.RegisterDiscoverable(&StateSyncEngine{}, discoverables)


### PR DESCRIPTION
**Problem:**
The SSE registers the INITtoSYNC mutation's failto with an id of "core". This will never get called because the sse registers it's discoverables with an id of "sse".

**Solution:**
Change the failto id of INITtoSYNC to "sse".

Tested on cray.