### PR TITLE
Migrate vbox demo to CentOS 8

### DIFF
--- a/config/vbox.yaml
+++ b/config/vbox.yaml
@@ -1,8 +1,7 @@
 # kraken-build.go: describes a build for a Virtualbox testbed
 targets:
-  'u-root':
-  'linux-amd64':
-    os: 'linux'
+  'darwin-amd64':
+    os: 'darwin'
     arch: 'amd64'
 
 # included extensions

--- a/config/vbox.yaml
+++ b/config/vbox.yaml
@@ -1,7 +1,7 @@
 # kraken-build.go: describes a build for a Virtualbox testbed
 targets:
-  'darwin-amd64':
-    os: 'darwin'
+  'linux-amd64':
+    os: 'linux'
     arch: 'amd64'
 
 # included extensions

--- a/examples/vbox/Vagrantfile
+++ b/examples/vbox/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.require_version ">= 2.0.0"
 Vagrant.configure("2") do |config|
   config.vm.define "kraken" do |kraken|
     kraken.vm.hostname = "kraken"
-    kraken.vm.box = "centos/7"
+    kraken.vm.box = "centos/8"
     kraken.vm.network "private_network",
       ip: "192.168.57.10",
       netmask: "255.255.255.0",

--- a/examples/vbox/roles/kraken-build-img/tasks/main.yml
+++ b/examples/vbox/roles/kraken-build-img/tasks/main.yml
@@ -24,6 +24,11 @@
     remote_src: yes
     mode: 0600
 
+- name: Create random_seed.dat for child VMs
+  command: "dd if=/dev/urandom of={{ kr_img_base }}/random_seed.dat bs=1k count=4"
+  args:
+    creates: "{{ kr_img_base }}/random_seed.dat"
+
 - name: Create boot image
   shell: "sh {{ kr_src_dir }}/utils/layer0/buildlayer0.sh -o initramfs.cpio.gz -b {{ kr_img_base }} -k {{ kr_src_dir }} amd64"
   args:

--- a/examples/vbox/roles/kraken-tftpboot/defaults/main.yml
+++ b/examples/vbox/roles/kraken-tftpboot/defaults/main.yml
@@ -1,3 +1,3 @@
 kr_tftp_base: /home/vagrant/tftp
 kr_pxelinux_cfg: /home/vagrant/support/pxelinux.cfg
-syslinux_tftpboot: /var/lib/tftpboot
+syslinux_tftpboot: /tftpboot

--- a/utils/layer0/buildlayer0.sh
+++ b/utils/layer0/buildlayer0.sh
@@ -118,7 +118,7 @@ if [ ! -x $GOPATH/bin/u-root ]; then
     GOPATH=$GOPATH go get github.com/u-root/u-root
 fi
 echo "Creating image..."
-GOARCH=$ARCH $GOPATH/bin/u-root -base $TMPDIR/base.cpio -build bb -o $TMPDIR/initramfs.cpio
+GOARCH=$ARCH $GOPATH/bin/u-root -base $TMPDIR/base.cpio -build bb -o $TMPDIR/initramfs.cpio core boot github.com/u-root/u-root/cmds/exp/* github.com/jlowellwofford/entropy/cmd/entropy
 
 echo "Compressing..."
 gzip $TMPDIR/initramfs.cpio

--- a/utils/layer0/buildlayer0.sh
+++ b/utils/layer0/buildlayer0.sh
@@ -117,6 +117,12 @@ if [ ! -x $GOPATH/bin/u-root ]; then
     echo "You don't appear to have u-root installed, attempting to install it"
     GOPATH=$GOPATH go get github.com/u-root/u-root
 fi
+
+if [ ! -x $GOPATH/bin/entropy ]; then
+    echo "You don't appear to have entropyinstalled, attempting to install it"
+    GOPATH=$GOPATH go get -u github.com/jlowellwofford/entropy/cmd/entropy
+fi
+
 echo "Creating image..."
 GOARCH=$ARCH $GOPATH/bin/u-root -base $TMPDIR/base.cpio -build bb -o $TMPDIR/initramfs.cpio core boot github.com/u-root/u-root/cmds/exp/* github.com/jlowellwofford/entropy/cmd/entropy
 

--- a/utils/layer0/uinit/uinit.go
+++ b/utils/layer0/uinit/uinit.go
@@ -133,13 +133,11 @@ func main() {
 			Background: false,
 			Args:       []string{"/bbin/sleep", "2"},
 		},
-		/* we don't use dhcp with kraken
-		command{
-			Cmd:        "/bbin/dhclient",
+		{
+			Cmd:        "/bbin/entropy",
 			Background: false,
-			Args:       []string{"/bbin/dhclient", "eth0"},
+			Args:       []string{"/bbin/entropy", "add", "random_seed.dat"},
 		},
-		*/
 		{
 			Cmd:        "/bbin/ip",
 			Background: false,


### PR DESCRIPTION
This PR integrates several changes necessary to migrate the vbox demo to use CentOS 8, including:
- Some ansible role tweaks
- Rev-ing the vagrant box
- Fixing an issue where CentOS 8 child VMs don't generate enough randomness at boot time to handle basic startup operations.  This is fixed by running github.com/jlowellwofford/entropy at startup time with a 4k random data file injected from the master.