### PR TITLE
Add interface name to parameters that tftp can template

### DIFF
--- a/examples/vbox/support/pxelinux.cfg/default.tpl
+++ b/examples/vbox/support/pxelinux.cfg/default.tpl
@@ -6,4 +6,4 @@ MENU TITLE Main Menu
 LABEL node
     MENU LABEL Boot x86_64 Compute Node (diskless)
     KERNEL vmlinuz
-    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}}
+    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.iface={{.Iface}} kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}}

--- a/modules/pxe/tftp.go
+++ b/modules/pxe/tftp.go
@@ -61,13 +61,17 @@ func (px *PXE) writeToTFTP(filename string, rf io.ReaderFrom) (e error) {
 		}
 		// file doesn't exist, but template does
 		// we could potentially make a lot more data than this available
+		// this is the basic stuff that's needed to get linked up with the parent
 		type tplData struct {
+			Iface    string
 			IP       string
 			CIDR     string
 			ID       string
 			ParentIP string
 		}
 		data := tplData{}
+		iface, _ := n.GetValue(px.cfg.SrvIfaceUrl)
+		data.Iface = iface.String()
 		i, _ := n.GetValue(px.cfg.IpUrl)
 		data.IP = IPv4.BytesToIP(i.Bytes()).String()
 		i, _ = n.GetValue(px.cfg.NmUrl)


### PR DESCRIPTION
...helps support different interface names without static uinit script changes.