### PR TITLE
Add sdnotify and prefix-free logging

### DIFF
--- a/core/Logger.go
+++ b/core/Logger.go
@@ -61,9 +61,10 @@ var _ lib.Logger = (*WriterLogger)(nil)
 // A WriterLogger writes to any io.Writer interface, e.g. stdout, stderr, or an open file
 // NOTE: Does not close the interface
 type WriterLogger struct {
-	w  io.Writer
-	m  string
-	lv lib.LoggerLevel
+	w             io.Writer
+	m             string
+	lv            lib.LoggerLevel
+	DisablePrefix bool
 }
 
 // Log submits a Log message with a LoggerLevel
@@ -73,11 +74,20 @@ func (l *WriterLogger) Log(lv lib.LoggerLevel, m string) {
 		if int(lv) <= len(lib.LoggerLevels)+1 {
 			plv = lib.LoggerLevels[lv]
 		}
-		s := []string{
-			time.Now().Format("15:04:05.000"),
-			l.m,
-			plv,
-			strings.TrimSpace(m) + "\n",
+		var s []string
+		if !l.DisablePrefix {
+			s = []string{
+				time.Now().Format("15:04:05.000"),
+				l.m,
+				plv,
+				strings.TrimSpace(m) + "\n",
+			}
+		} else {
+			s = []string{
+				l.m,
+				plv,
+				strings.TrimSpace(m) + "\n",
+			}
 		}
 		l.w.Write([]byte(strings.Join(s, ":")))
 	}

--- a/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
+++ b/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
@@ -5,10 +5,9 @@ Requires=network.target
 
 [Service]
 EnvironmentFile=/etc/sysconfig/kraken
-Type=simple
+Type=notify
 WorkingDirectory={{ kraken_working_directory }}
-ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL"
-ExecStartPost=sleep 2
+ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
 ExecStartPost=/bin/bash -c '/usr/bin/curl -XPOST -H "Content-type: application/json" -d "@$KRAKEN_STATE_FILE" "http://$KRAKEN_IPAPI:3141/cfg/nodes"'
 
 [Install]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/hpc/kraken
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/golang/protobuf v1.4.3
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 
+	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hpc/kraken/core"
 	"github.com/hpc/kraken/lib"
@@ -35,6 +36,8 @@ func main() {
 	ipapi := flag.String("ipapi", "127.0.0.1", "what IP to use for the ReST API")
 	parent := flag.String("parent", "", "IP adddress of parent")
 	llevel := flag.Int("log", 3, "set the log level (0-9)")
+	sdnotify := flag.Bool("sdnotify", false, "notify systemd when kraken is initialized")
+	journald := flag.Bool("journald", false, "assuming we are logging through journald, disable log prefixes")
 	flag.Parse()
 
 	// Create a new logger interface
@@ -42,6 +45,9 @@ func main() {
 	log.RegisterWriter(os.Stderr)
 	log.SetModule("main")
 	log.SetLoggerLevel(lib.LoggerLevel(*llevel))
+	if *journald {
+		log.DisablePrefix = true
+	}
 
 	// Launch as base Kraken or module?
 	//me := filepath.Base(os.Args[0])
@@ -155,6 +161,16 @@ func main() {
 	// Thaw if full state
 	if len(parents) == 0 {
 		k.Sme.Thaw()
+	}
+
+	// notify systemd?
+	if *sdnotify {
+		sent, err := daemon.SdNotify(false, daemon.SdNotifyReady)
+		if err != nil {
+			log.Logf(lib.LLCRITICAL, "failed to send sd_notify: %v", err)
+		} else if !sent {
+			log.Logf(lib.LLWARNING, "sdnotify was requested, but notification is not supported")
+		}
 	}
 
 	// wait forever

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -170,6 +170,8 @@ func main() {
 			log.Logf(lib.LLCRITICAL, "failed to send sd_notify: %v", err)
 		} else if !sent {
 			log.Logf(lib.LLWARNING, "sdnotify was requested, but notification is not supported")
+		} else {
+			log.Logf(lib.LLNOTICE, "successfuly sent sdnotify ready")
 		}
 	}
 


### PR DESCRIPTION
`-sdnotify` allows kraken to let systemd know when kraken is initialized.  This can greatly improve systemd dependency tracking.
`-journald` tells kraken to leave off the usual prefix on log messages, since we expect journald to take care of that.
