### PR TITLE
Initial state injection from files

### DIFF
--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -85,7 +85,7 @@ type StateDifferenceEngine struct {
 }
 
 // NewStateDifferenceEngine initializes a new StateDifferenceEngine object given a Context
-func NewStateDifferenceEngine(me lib.Node, ctx Context, qc chan lib.Query) *StateDifferenceEngine {
+func NewStateDifferenceEngine(ctx Context, qc chan lib.Query) *StateDifferenceEngine {
 	n := &StateDifferenceEngine{}
 	n.dsc = NewState()
 	n.cfg = NewState()
@@ -94,7 +94,12 @@ func NewStateDifferenceEngine(me lib.Node, ctx Context, qc chan lib.Query) *Stat
 	n.schan = ctx.SubChan
 	n.log = &ctx.Logger
 	n.log.SetModule("StateDifferenceEngine")
-	n.Create(me)
+	// load initial states
+	n.BulkCreate(ctx.SDE.InitialCfg)
+	n.BulkUpdateDsc(ctx.SDE.InitialDsc)
+	// we're done with this now, so no need to keep them around
+	ctx.SDE.InitialCfg = []lib.Node{}
+	ctx.SDE.InitialDsc = []lib.Node{}
 	return n
 }
 

--- a/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
+++ b/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
@@ -7,10 +7,7 @@ Requires=network.target
 EnvironmentFile=/etc/sysconfig/kraken
 Type=notify
 WorkingDirectory={{ ansible_env.HOME }}
-ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
-# this is a temporary hack to load state
-ExecStartPost=sleep 2
-ExecStartPost=/bin/bash -c '/usr/bin/curl -XPOST -H "Content-type: application/json" -d "@$KRAKEN_STATE_FILE" "http://$KRAKEN_IPAPI:3141/cfg/nodes"'
+ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
+++ b/examples/vbox/ansible/roles/kraken-systemd/templates/kraken.service.j2
@@ -7,7 +7,7 @@ Requires=network.target
 EnvironmentFile=/etc/sysconfig/kraken
 Type=notify
 WorkingDirectory={{ ansible_env.HOME }}
-ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
+ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -noprefix -sdnotify
 
 [Install]
 WantedBy=multi-user.target

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -130,6 +130,7 @@ func main() {
 
 	// Parse -cfg file
 	if *cfg != "" {
+		log.Logf(lib.LLINFO, "loading initial configuration state from: %s", *cfg)
 		data, e := ioutil.ReadFile(*cfg)
 		if e != nil {
 			fmt.Printf("failed to read cfg state file: %s, %v", *cfg, e)
@@ -142,8 +143,10 @@ func main() {
 			flag.PrintDefaults()
 			return
 		}
+		log.Logf(lib.LLDEBUG, "found initial state information for %d nodes", len(pbs.Nodes))
 		for _, m := range pbs.GetNodes() {
 			n := core.NewNodeFromMessage(m)
+			log.Logf(lib.LLDDDEBUG, "got node state for node: %s", n.ID().String())
 			if n.ID().Equal(self.ID()) {
 				// we found ourself
 				self.Merge(n, "")

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -12,6 +12,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -37,15 +38,22 @@ func main() {
 	parent := flag.String("parent", "", "IP adddress of parent")
 	llevel := flag.Int("log", 3, "set the log level (0-9)")
 	sdnotify := flag.Bool("sdnotify", false, "notify systemd when kraken is initialized")
-	journald := flag.Bool("journald", false, "assuming we are logging through journald, disable log prefixes")
+	logprefix := flag.Bool("logprefix", true, "prefix log messages with timestamps")
+	cfg := flag.String("cfg", "", "path to a JSON file containing initial configuration state to load")
 	flag.Parse()
+
+	// This gives us an easy way to distinguesh when a flag happened to be set to its default
+	// And when a flag wasn't specified.  We give those two things differen precedence.
+	// If the flag was set, it will override -cfg values, even if it's the default.
+	setFlags := make(map[string]bool)
+	flag.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
 
 	// Create a new logger interface
 	log := &core.WriterLogger{}
 	log.RegisterWriter(os.Stderr)
 	log.SetModule("main")
 	log.SetLoggerLevel(lib.LoggerLevel(*llevel))
-	if *journald {
+	if *logprefix {
 		log.DisablePrefix = true
 	}
 
@@ -94,8 +102,11 @@ func main() {
 
 	// Build our starting node (CFG) state based on command line arguments
 	self := core.NewNodeWithID(*idstr)
+	selfDsc := core.NewNodeWithID(*idstr)
 
-	{ // Enable the restapi by default
+	// Set some defaults if we're a full state node
+	if len(parents) == 0 {
+		// Enable the restapi by default
 		conf := &rpb.RestAPIConfig{
 			Addr: *ipapi,
 			Port: 3141,
@@ -107,9 +118,44 @@ func main() {
 		if _, e := self.SetValue("/Services/restapi/State", reflect.ValueOf(cpb.ServiceInstance_RUN)); e != nil {
 			log.Logf(lib.LLERROR, "couldn't set value /Services/restapi/State -> %+v: %v", reflect.ValueOf(cpb.ServiceInstance_RUN), e)
 		}
+
+		// Set our run/phys states.  If we're full state these are implicit
+		self.SetValue("/PhysState", reflect.ValueOf(cpb.Node_POWER_ON))
+		selfDsc.SetValue("/PhysState", reflect.ValueOf(cpb.Node_POWER_ON))
+		self.SetValue("/RunState", reflect.ValueOf(cpb.Node_SYNC))
+		selfDsc.SetValue("/RunState", reflect.ValueOf(cpb.Node_SYNC))
 	}
 
-	{ // Populate interface0 information based on IP
+	nodes := []lib.Node{}
+
+	// Parse -cfg file
+	if *cfg != "" {
+		data, e := ioutil.ReadFile(*cfg)
+		if e != nil {
+			fmt.Printf("failed to read cfg state file: %s, %v", *cfg, e)
+			flag.PrintDefaults()
+			return
+		}
+		var pbs cpb.NodeList
+		if e = core.UnmarshalJSON(data, &pbs); e != nil {
+			fmt.Printf("could not parse cfg state file: %s, %v", *cfg, e)
+			flag.PrintDefaults()
+			return
+		}
+		for _, m := range pbs.GetNodes() {
+			n := core.NewNodeFromMessage(m)
+			if n.ID().Equal(self.ID()) {
+				// we found ourself
+				self.Merge(n, "")
+			} else {
+				// note: duplicates will cause a later failure
+				nodes = append(nodes, n)
+			}
+		}
+	}
+
+	// Populate interface0 information based on IP (iff cfg wasn't specified, or ip was explicitly specified)
+	if ok, _ := setFlags["ip"]; *cfg == "" || ok {
 		netIP := net.ParseIP(*ip)
 		if netIP == nil {
 			log.Logf(lib.LLCRITICAL, "could not parse IP address: %s", *ip)
@@ -156,9 +202,13 @@ func main() {
 
 	// Launch Kraken
 	k := core.NewKraken(self, parents, log)
+	if len(nodes) > 0 {
+		k.Ctx.SDE.InitialCfg = append(k.Ctx.SDE.InitialCfg, nodes...)
+	}
+	k.Ctx.SDE.InitialDsc = []lib.Node{selfDsc}
 	k.Release()
 
-	// Thaw if full state
+	// Thaw if full state and not told to freeze
 	if len(parents) == 0 {
 		k.Sme.Thaw()
 	}

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -38,7 +38,7 @@ func main() {
 	parent := flag.String("parent", "", "IP adddress of parent")
 	llevel := flag.Int("log", 3, "set the log level (0-9)")
 	sdnotify := flag.Bool("sdnotify", false, "notify systemd when kraken is initialized")
-	logprefix := flag.Bool("logprefix", true, "prefix log messages with timestamps")
+	noprefix := flag.Bool("noprefix", true, "don't prefix log messages with timestamps")
 	cfg := flag.String("cfg", "", "path to a JSON file containing initial configuration state to load")
 	flag.Parse()
 
@@ -53,7 +53,7 @@ func main() {
 	log.RegisterWriter(os.Stderr)
 	log.SetModule("main")
 	log.SetLoggerLevel(lib.LoggerLevel(*llevel))
-	if *logprefix {
+	if *noprefix {
 		log.DisablePrefix = true
 	}
 

--- a/utils/rpm/kraken.service
+++ b/utils/rpm/kraken.service
@@ -7,10 +7,7 @@ Requires=network.target
 EnvironmentFile=%{_sysconfdir}/sysconfig/kraken
 Type=notify
 WorkingDirectory=%{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}
-ExecStart=%{_sbindir}/kraken -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
-# this is a temporary hack to load state
-ExecStartPost=sleep 2
-ExecStartPost=/bin/bash -c '/usr/bin/curl -XPOST -H "Content-type: application/json" -d "@$KRAKEN_STATE_FILE" "http://$KRAKEN_IPAPI:3141/cfg/nodes"'
+ExecStart=%{_sbindir}/kraken -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
 
 [Install]
 WantedBy=multi-user.target

--- a/utils/rpm/kraken.service
+++ b/utils/rpm/kraken.service
@@ -7,7 +7,7 @@ Requires=network.target
 EnvironmentFile=%{_sysconfdir}/sysconfig/kraken
 Type=notify
 WorkingDirectory=%{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}
-ExecStart=%{_sbindir}/kraken -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -journald -sdnotify
+ExecStart=%{_sbindir}/kraken -cfg "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -noprefix -sdnotify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds the ability to pass `-state <file.json>` to kraken at start-up, and have initial state defined for nodes described in that file.  This can include the full-state node itself, and can be used to change initial service configurations (for instance).