### PR TITLE
kraken.spec:  Add newline to build targets

### DIFF
--- a/utils/rpm/kraken.spec
+++ b/utils/rpm/kraken.spec
@@ -38,6 +38,7 @@ rpm -D "KrakenWorkingDirectory %{?KrakenWorkingDirectory}%{?!KrakenWorkingDirect
 rpm --eval "$(cat utils/rpm/kraken.environment)" > kraken.environment
 
 cat << EOF >> build.yaml 
+
 targets:
   'rpm':
     os: 'linux'


### PR DESCRIPTION
Trivial bugfix - If the kraken config file defined by
`%{KrakenConfig}` happens to not have a trailing newline, the
`targets:` label will wind up getting tacked onto the end of the last
line of that config file rather than at BOL as it should.

For safety/paranoia, this prepends the YAML snippet with a newline
since YAML doesn't mind blank lines, and this way we don't have to
worry about whether or not the previous contents have the trailing
newline.