### PR TITLE
Build more rpms

### DIFF
--- a/utils/layer0/buildlayer0_uroot.sh
+++ b/utils/layer0/buildlayer0_uroot.sh
@@ -107,21 +107,20 @@ echo "Using generated kraken source tree at $KRAKEN_BUILDDIR"
 # Check that gobusybox is installed, clone it if not
 if [ ! -d "$GOPATH"/bin/makebb ]; then
     echo "You don't appear to have gobusybox installed, attempting to install it"
-    GOPATH="$GOPATH" go get github.com/u-root/gobusybox
-    ( cd "$GOPATH"/src/github.com/u-root/gobusybox/src/cmd/makebb && GOPATH="$GOPATH" go install )
+    GOPATH="$GOPATH" GO111MODULE=off go get github.com/u-root/gobusybox/src/cmd/makebb
 fi
 
 # Check that u-root is installed, clone it if not
 if [ ! -x "$GOPATH"/bin/u-root ]; then
     echo "You don't appear to have u-root installed, attempting to install it"
-    GOPATH="$GOPATH" go get github.com/u-root/u-root
+    GOPATH="$GOPATH" GO111MODULE=off go get github.com/u-root/u-root
 fi
 
 # Make sure commands are available
 for c in "${EXTRA_COMMANDS[@]}"; do
    if [ ! -d "$GOPATH/src/$c" ]; then
     echo "You don't appear to have $c, attempting to install it"
-    GOPATH=$GOPATH go get "$c"
+    GOPATH=$GOPATH GO111MODULE=off go get "$c"
    fi
 done
 

--- a/utils/powermanapi/powermanapi.environment
+++ b/utils/powermanapi/powermanapi.environment
@@ -1,0 +1,8 @@
+# POWERMAN_BASE specifies the URL root for the api
+POWERMAN_BASE="/powermancontrol"
+# POWERMAN_PMC specifies the powerman command to use (e.g. pm vs powerman)
+POWERMAN_PMC="powerman"
+# POWERMAN_IP specifies the IP that the powermanapi will listen on
+POWERMAN_IP="127.0.0.1"
+# POWERMAN_PORT specifies the network port that powermanapi will listen on
+POWERMAN_PORT=8269

--- a/utils/powermanapi/powermanapi.service
+++ b/utils/powermanapi/powermanapi.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Powerman API Service
+After=network.target network-online.target
+Requires=network.target
+
+[Service]
+EnvironmentFile=%{_sysconfdir}/sysconfig/powermanapi
+Type=simple
+ExecStart=%{_sbindir}/powermanapi -ip "$POWERMAN_IP" -port "$POWERMAN_PORT" -pmc "$POWERMAN_PMC" -base "$POWERMAN_BASE"
+
+[Install]
+WantedBy=multi-user.target

--- a/utils/rpm/kraken.spec
+++ b/utils/rpm/kraken.spec
@@ -28,6 +28,15 @@ BuildRequires:  go, golang >= 1.15, golang-bin, golang-src
 %description
 Kraken is a distributed state engine that can maintain state across a large set of computers. It was designed to provide full-lifecycle maintenance of HPC compute clusters, from cold boot to ongoing system state maintenance and automation.
 
+# Define initramfs-<arch> sub-package
+%package initramfs-%{GoBuildArch}
+BuildArch: noarch
+Group: Applications/System
+Summary: A base initramfs for use with Kraken PXE configurations (%{GoBuildArch}).
+%description initramfs-%{GoBuildArch}
+This package installs a pre-built base initramfs (arch: %{GoBuildArch}) for use with a Kraken PXE setup.  This initramfs should be layered with at least two other pieces: 1. a set of needed system modules; 2. a set of configuration files (e.g. uinit.script).
+
+
 %prep
 %setup -q
 cp -p %{?KrakenConfig}%{?!KrakenConfig:kraken.yaml} build.yaml
@@ -43,9 +52,19 @@ targets:
   'rpm':
     os: 'linux'
     arch: '%{GoBuildArch}'
+  'u-root':
 EOF
 
 go run kraken-build.go -force -v -config build.yaml
+
+# build initramfs
+export GOPATH=%{_builddir}/go
+mkdir -p $GOPATH/src/github.com/hpc
+ln -s $PWD $GOPATH/src/github.com/hpc/kraken
+bash utils/layer0/buildlayer0_uroot.sh -o initramfs-base-%{GoBuildArch}.gz %{GoBuildArch}
+
+chmod -R u+w $GOPATH
+rm -rf $GOPATH
 
 %install
 mkdir -p %{buildroot}
@@ -53,6 +72,7 @@ install -D -m 0755 build/kraken-rpm %{buildroot}%{_sbindir}/kraken
 install -D -m 0644 kraken.service %{buildroot}%{_unitdir}/kraken.service
 install -D -m 0644 kraken.environment %{buildroot}%{_sysconfdir}/sysconfig/kraken
 install -D -m 0644 utils/rpm/state.json %{buildroot}%{_sysconfdir}/kraken/state.json
+install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-base-%{GoBuildArch}.gz
 
 %files
 %defattr(-,root,root)
@@ -61,6 +81,9 @@ install -D -m 0644 utils/rpm/state.json %{buildroot}%{_sysconfdir}/kraken/state.
 %config(noreplace) %{_sysconfdir}/kraken/state.json
 %{_unitdir}/kraken.service
 %config(noreplace) %{_sysconfdir}/sysconfig/kraken
+
+%files initramfs-%{GoBuildArch}
+/tftp/initramfs-base-%{GoBuildArch}.gz
 
 %changelog
 

--- a/utils/rpm/kraken.spec
+++ b/utils/rpm/kraken.spec
@@ -36,6 +36,12 @@ Summary: A base initramfs for use with Kraken PXE configurations (%{GoBuildArch}
 %description initramfs-%{GoBuildArch}
 This package installs a pre-built base initramfs (arch: %{GoBuildArch}) for use with a Kraken PXE setup.  This initramfs should be layered with at least two other pieces: 1. a set of needed system modules; 2. a set of configuration files (e.g. uinit.script).
 
+%package powermanapi
+Group: Applications/System
+Requires: powerman
+Summary: The powermanapi wraps the powerman service with a simple restful API service.
+%description powermanapi
+The powermanapi service wraps the powerman service with a simple restful API service that can be used by Kraken.
 
 %prep
 %setup -q
@@ -43,9 +49,13 @@ cp -p %{?KrakenConfig}%{?!KrakenConfig:kraken.yaml} build.yaml
 
 %build
 
+# template systemd units
 rpm -D "KrakenWorkingDirectory %{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}" --eval "$(cat utils/rpm/kraken.service)" > kraken.service
 rpm --eval "$(cat utils/rpm/kraken.environment)" > kraken.environment
+rpm --eval "$(cat utils/powermanapi/powermanapi.service)" > powermanapi.service
+rpm --eval "$(cat utils/powermanapi/powermanapi.environment)" > powermanapi.environment
 
+# build kraken
 cat << EOF >> build.yaml 
 
 targets:
@@ -56,6 +66,12 @@ targets:
 EOF
 
 go run kraken-build.go -force -v -config build.yaml
+
+# build powermanapi
+(
+  cd utils/powermanapi
+  GOARCH=%{GoBuildArch} go build powermanapi.go
+)
 
 # build initramfs
 export GOPATH=%{_builddir}/go
@@ -68,10 +84,16 @@ rm -rf $GOPATH
 
 %install
 mkdir -p %{buildroot}
+# kraken
 install -D -m 0755 build/kraken-rpm %{buildroot}%{_sbindir}/kraken
 install -D -m 0644 kraken.service %{buildroot}%{_unitdir}/kraken.service
 install -D -m 0644 kraken.environment %{buildroot}%{_sysconfdir}/sysconfig/kraken
 install -D -m 0644 utils/rpm/state.json %{buildroot}%{_sysconfdir}/kraken/state.json
+# powermanapi
+install -D -m 0755 utils/powermanapi/powermanapi %{buildroot}%{_sbindir}/powermanapi
+install -D -m 0644 powermanapi.service %{buildroot}%{_unitdir}/powermanapi.service
+install -D -m 0644 powermanapi.environment %{buildroot}%{_sysconfdir}/sysconfig/powermanapi
+# initramfs
 install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-base-%{GoBuildArch}.gz
 
 %files
@@ -82,10 +104,20 @@ install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-
 %{_unitdir}/kraken.service
 %config(noreplace) %{_sysconfdir}/sysconfig/kraken
 
+%files powermanapi
+%license LICENSE
+%{_sbindir}/powermanapi
+%config(noreplace) %{_sysconfdir}/sysconfig/powermanapi
+%{_unitdir}/powermanapi.service
+
 %files initramfs-%{GoBuildArch}
+%license LICENSE
 /tftp/initramfs-base-%{GoBuildArch}.gz
 
 %changelog
+
+* Tue Jan 26 2021 J. Lowell Wofford <lowell@lanl.gov> 1.0-1
+- Add initramfs, powermanapi, and vboxapi packages
 
 * Wed Jan 13 2021 J. Lowell Wofford <lowell@lanl.gov> 1.0-0
 - Initial RPM build of kraken

--- a/utils/vboxapi/vboxapi.environment
+++ b/utils/vboxapi/vboxapi.environment
@@ -1,0 +1,8 @@
+# VBOXAPI_BASE specifies the URL root for the api
+VBOXAPI_BASE="/vboxmanage"
+# VBOXAPI_VBM specifies the vbox manage command to use
+VBOXAPI_VBM="/usr/local/bin/vboxmanage"
+# VBOXAPI_IP specifies the IP that the vboxapi will listen on
+VBOXAPI_IP="127.0.0.1"
+# VBOXAPI_PORT specifies the network port that vboxapi will listen on
+VBOXAPI_PORT=8269

--- a/utils/vboxapi/vboxapi.service
+++ b/utils/vboxapi/vboxapi.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=VirtualBox API Service
+After=network.target network-online.target
+Requires=network.target
+
+[Service]
+EnvironmentFile=%{_sysconfdir}/sysconfig/vboxapi
+Type=simple
+ExecStart=%{_sbindir}/vboxapi -ip "$VBOXAAPI_IP" -port "$VBOXAAPI_PORT" -vbm "$VBOXAAPI_VBM" -base "$VBOXAAPI_BASE"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds three packages to the `kraken.spec` file to build three additional RPMs.
1. the `initramfs-base-<arch>` package installs a base initramfs that can be used for pxe deployements.
2. the `powermanapi` package installs the powermanapi service (along with systemd units)
3. the `vboxapi` package installs the vboxapi service (along with systemd units)
