### PR TITLE
Runtime config fixups

### DIFF
--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -385,8 +385,8 @@ func main() {
 		}
 	}
 
-	// Populate interface0 information based on IP (iff cfg wasn't specified, or ip was explicitly specified)
-	if ok, _ := setFlags["ip"]; rc.StateFile == "" || ok {
+	// Populate interface0 information based on IP (if it doesn't already exist from the state file)
+	if _, e := self.GetValue("type.googleapis.com/IPv4.IPv4OverEthernet/Ifaces/kraken/Ip/Ip"); e != nil {
 		iface := net.Interface{}
 		network := net.IPNet{}
 		ifaces, e := net.Interfaces()

--- a/kraken/main.go.tpl
+++ b/kraken/main.go.tpl
@@ -438,7 +438,7 @@ func main() {
 	k.Release()
 
 	// Thaw if full state and not told to freeze
-	if len(parents) == 0 || !rc.Freeze {
+	if fullStateNode && !rc.Freeze {
 		k.Sme.Thaw()
 	}
 

--- a/utils/ansible/roles/kraken-systemd/tasks/main.yml
+++ b/utils/ansible/roles/kraken-systemd/tasks/main.yml
@@ -9,14 +9,19 @@
     mode: 0644
   when: not kr_rpm
 
-- name: Install kraken environment file
+- name: Write the kraken runtime configuration file
   become: true
-  template:
-    src: 'kraken.environment.j2'
-    dest: '/etc/sysconfig/kraken'
-    owner: root
-    group: root
-    mode: 0644
+  shell:
+    cmd: >
+      /usr/sbin/kraken -printrc
+      -id "{{ kraken_id }}"
+      -ip "{{ kraken_ip }}"
+      -ipapi "{{ kraken_ipapi }}"
+      -log "{{ kraken_loglevel }}"
+      -state "{{ kraken_state_file }}"
+      > /etc/kraken/config.yaml
+      && touch /etc/kraken/.ansible_config
+    creates: /etc/kraken/.ansible_config
 
 - name: Enable & start kraken service
   become: true

--- a/utils/ansible/roles/kraken-systemd/templates/kraken.environment.j2
+++ b/utils/ansible/roles/kraken-systemd/templates/kraken.environment.j2
@@ -1,6 +1,0 @@
-KRAKEN_CONFIG_FILE=/etc/kraken/config.yaml
-KRAKEN_UUID={{ kraken_id }}
-KRAKEN_IP={{ kraken_ip }}
-KRAKEN_IPAPI={{ kraken_ipapi }}
-KRAKEN_LOGLEVEL={{ kraken_loglevel }}
-KRAKEN_STATE_FILE={{ kraken_state_file }}

--- a/utils/ansible/roles/kraken-systemd/templates/kraken.service.j2
+++ b/utils/ansible/roles/kraken-systemd/templates/kraken.service.j2
@@ -4,10 +4,9 @@ After=network.target network-online.target
 Requires=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/kraken
 Type=notify
 WorkingDirectory={{ ansible_env.HOME }}
-ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -config "$KRAKEN_CONFIG_FILE" -state "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -noprefix -sdnotify
+ExecStart={{ kr_build_dir ~ '/' ~ kr_target }} -config /etc/kraken/config.yaml -sdnotify -noprefix
 
 [Install]
 WantedBy=multi-user.target

--- a/utils/rpm/kraken.environment
+++ b/utils/rpm/kraken.environment
@@ -1,6 +1,0 @@
-KRAKEN_CONFIG_FILE=%{_sysconfigdir}/kraken/config.yaml
-KRAKEN_UUID=123e4567-e89b-12d3-a456-426655440000
-KRAKEN_IP=127.0.0.1
-KRAKEN_IPAPI=127.0.0.1
-KRAKEN_LOGLEVEL=7
-KRAKEN_STATE_FILE=%{_sysconfdir}/kraken/state.json

--- a/utils/rpm/kraken.service
+++ b/utils/rpm/kraken.service
@@ -4,10 +4,9 @@ After=network.target network-online.target
 Requires=network.target
 
 [Service]
-EnvironmentFile=%{_sysconfdir}/sysconfig/kraken
 Type=notify
 WorkingDirectory=%{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}
-ExecStart=%{_sbindir}/kraken -config "$KRAKEN_CONFIG_FILE" -state "$KRAKEN_STATE_FILE" -id "$KRAKEN_UUID" -ip "$KRAKEN_IP" -ipapi "$KRAKEN_IPAPI" -log "$KRAKEN_LOGLEVEL" -noprefix -sdnotify
+ExecStart=%{_sbindir}/kraken -config %{_sysconfdir}/kraken/config.yaml -noprefix -sdnotify
 
 [Install]
 WantedBy=multi-user.target

--- a/utils/rpm/kraken.spec
+++ b/utils/rpm/kraken.spec
@@ -64,7 +64,6 @@ cp -p %{?KrakenConfig}%{?!KrakenConfig:kraken.yaml} build.yaml
 
 # template systemd units
 rpm -D "KrakenWorkingDirectory %{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}" --eval "$(cat utils/rpm/kraken.service)" > kraken.service
-rpm --eval "$(cat utils/rpm/kraken.environment)" > kraken.environment
 rpm --eval "$(cat utils/powermanapi/powermanapi.service)" > powermanapi.service
 rpm --eval "$(cat utils/powermanapi/powermanapi.environment)" > powermanapi.environment
 rpm --eval "$(cat utils/vboxapi/vboxapi.service)" > vboxapi.service
@@ -89,7 +88,7 @@ EOF
 go run kraken-build.go -force -v -config build.yaml
 
 # create default runtime config file
-build/kraken-native -state "/etc/kraken/state.json" -printrc > defaults.yaml
+build/kraken-native -state "/etc/kraken/state.json" -noprefix -sdnotify -printrc > defaults.yaml
 
 %if %{with powermanapi}
 # build powermanapi
@@ -123,7 +122,6 @@ mkdir -p %{buildroot}
 # kraken
 install -D -m 0755 build/kraken-rpm %{buildroot}%{_sbindir}/kraken
 install -D -m 0644 kraken.service %{buildroot}%{_unitdir}/kraken.service
-install -D -m 0644 kraken.environment %{buildroot}%{_sysconfdir}/sysconfig/kraken
 install -D -m 0644 utils/rpm/state.json %{buildroot}%{_sysconfdir}/kraken/state.json
 install -D -m 0644 defaults.yaml %{buildroot}%{_sysconfdir}/kraken/config.yaml
 %if %{with powermanapi}
@@ -150,7 +148,6 @@ install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-
 %config(noreplace) %{_sysconfdir}/kraken/state.json
 %config(noreplace) %{_sysconfdir}/kraken/config.yaml
 %{_unitdir}/kraken.service
-%config(noreplace) %{_sysconfdir}/sysconfig/kraken
 
 %if %{with powermanapi}
 %files powermanapi


### PR DESCRIPTION
We fix three issues with runtime configs:
1. freeze is now functional
2. logic for injecting our IP address into state is improved
3. we move all startup config to using the config file and eliminate `/etc/sysconfg/kraken`