### PR TITLE
Add multi-stage Dockerfile to Kraken

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.circleci
+.git*
+config.yaml
+state.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 **/.vscode
 /build
+config.yaml
+config/kitchensink.yaml
 tmp
 munge.key
 ssh_host_*key*
+state.json
 **/.DS_Store
 /kraken-build
 **/*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ ARG GOVER="1.15"
 ### Container #1:  Alpine-based Go dev env with Kraken built & installed
 ################################################################################
 FROM golang:${GOVER}-alpine AS kraken-build
-MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 ARG GOOS
@@ -46,8 +45,7 @@ CMD [ "--help" ]
 ################################################################################
 ### Container #2:  Pure Alpine container (no Go) with Kraken copied in
 ################################################################################
-FROM alpine AS kraken-alpine
-MAINTAINER Michael Jennings <mej@lanl.gov>
+FROM alpine:latest AS kraken-alpine
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 COPY --from=kraken-build /sbin/kraken /sbin/kraken
@@ -61,7 +59,6 @@ CMD [ "--help" ]
 ### Container #3:  Nothing but the Kraken executable (composable/sidecar)
 ################################################################################
 FROM scratch AS kraken-exe
-MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 COPY --from=kraken-build /sbin/kraken /sbin/kraken
@@ -75,7 +72,6 @@ CMD [ "--help" ]
 ### Container #4:  Above "kraken-build" container plus configs
 ################################################################################
 FROM kraken-build AS kraken-build-cfg
-MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 COPY config.yaml state.json /etc/kraken/
@@ -89,7 +85,6 @@ CMD [ "--help" ]
 ### Container #5:  Above "kraken-alpine" container plus configs
 ################################################################################
 FROM kraken-alpine AS kraken-alpine-cfg
-MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 COPY config.yaml state.json /etc/kraken/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG GOVER="1.15"
 ################################################################################
 ### Container #1:  Alpine-based Go dev env with Kraken built & installed
 ################################################################################
-FROM registry.lanl.gov:5000/golang:${GOVER}-alpine AS kraken-build
+FROM golang:${GOVER}-alpine AS kraken-build
 MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
@@ -46,7 +46,7 @@ CMD [ "--help" ]
 ################################################################################
 ### Container #2:  Pure Alpine container (no Go) with Kraken copied in
 ################################################################################
-FROM registry.lanl.gov:5000/alpine AS kraken-alpine
+FROM alpine AS kraken-alpine
 MAINTAINER Michael Jennings <mej@lanl.gov>
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ CMD [ "--help" ]
 ################################################################################
 ### Container #2:  Pure Alpine container (no Go) with Kraken copied in
 ################################################################################
-FROM alpine:latest AS kraken-alpine
+FROM alpine:3 AS kraken-alpine
 LABEL maintainer="Michael Jennings <mej@lanl.gov>"
 
 COPY --from=kraken-build /sbin/kraken /sbin/kraken

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,102 @@
+### -*- Mode: Dockerfile; fill-column: 80; comment-auto-fill-only-comments: t; tab-width: 4 -*-
+################################################################################
+#
+# Kraken Dockerfile
+#
+# Michael Jennings <mej@lanl.gov>
+# 05 Feb 2021
+#
+################################################################################
+
+### Build Arguments (override via "--build-arg")
+ARG GOARCH="${GOARCH:-amd64}"
+ARG GOOS="${GOOS:-linux}"
+ARG GOPATH="${GOPATH:-/go}"
+ARG GOVER="1.15"
+
+################################################################################
+### Container #1:  Alpine-based Go dev env with Kraken built & installed
+################################################################################
+FROM registry.lanl.gov:5000/golang:${GOVER}-alpine AS kraken-build
+MAINTAINER Michael Jennings <mej@lanl.gov>
+LABEL maintainer="Michael Jennings <mej@lanl.gov>"
+
+ARG GOOS
+ARG GOARCH
+ARG GOPATH
+ARG GOVER
+
+WORKDIR "${GOPATH}/src/kraken"
+COPY . .
+
+#RUN go get -d -v ...
+
+RUN export GOARCH="${GOARCH:-amd64}" GOOS="${GOOS:-linux}" GOPATH="${GOPATH:-/go}" \
+        && go build -v -o "${GOPATH}/bin/kraken-${GOOS}-${GOARCH}" \
+        && go install -v \
+        && cp -a "${GOPATH}/bin/kraken-${GOOS}-${GOARCH}" /sbin/ \
+        && ln -s "kraken-${GOOS}-${GOARCH}" /sbin/kraken \
+        && rm -rf "${GOPATH}/pkg"
+
+ENTRYPOINT [ "/sbin/kraken" ]
+CMD [ "--help" ]
+
+
+
+################################################################################
+### Container #2:  Pure Alpine container (no Go) with Kraken copied in
+################################################################################
+FROM registry.lanl.gov:5000/alpine AS kraken-alpine
+MAINTAINER Michael Jennings <mej@lanl.gov>
+LABEL maintainer="Michael Jennings <mej@lanl.gov>"
+
+COPY --from=kraken-build /sbin/kraken /sbin/kraken
+
+ENTRYPOINT [ "/sbin/kraken" ]
+CMD [ "--help" ]
+
+
+
+################################################################################
+### Container #3:  Nothing but the Kraken executable (composable/sidecar)
+################################################################################
+FROM scratch AS kraken-exe
+MAINTAINER Michael Jennings <mej@lanl.gov>
+LABEL maintainer="Michael Jennings <mej@lanl.gov>"
+
+COPY --from=kraken-build /sbin/kraken /sbin/kraken
+
+ENTRYPOINT [ "/sbin/kraken" ]
+CMD [ "--help" ]
+
+
+
+################################################################################
+### Container #4:  Above "kraken-build" container plus configs
+################################################################################
+FROM kraken-build AS kraken-build-cfg
+MAINTAINER Michael Jennings <mej@lanl.gov>
+LABEL maintainer="Michael Jennings <mej@lanl.gov>"
+
+COPY config.yaml state.json /etc/kraken/
+
+ENTRYPOINT [ "/sbin/kraken", "-config", "/etc/kraken/config.yaml", "-state", "/etc/kraken/state.json" ]
+CMD [ "--help" ]
+
+
+
+################################################################################
+### Container #5:  Above "kraken-alpine" container plus configs
+################################################################################
+FROM kraken-alpine AS kraken-alpine-cfg
+MAINTAINER Michael Jennings <mej@lanl.gov>
+LABEL maintainer="Michael Jennings <mej@lanl.gov>"
+
+COPY config.yaml state.json /etc/kraken/
+
+ENTRYPOINT [ "/sbin/kraken", "-config", "/etc/kraken/config.yaml", "-state", "/etc/kraken/state.json" ]
+CMD [ "--help" ]
+
+
+
+################################################################################


### PR DESCRIPTION
* Add new `Dockerfile` that uses multi-stage build features and techniques to support building multiple Alpine-based Kraken
  containers of various persuasions, from a full Go dev/build environment all the way down to just the `/sbin/kraken` executable
  itself.

* Also add a `.dockerignore` file (analogous to `.gitignore`) to prevent Git and CircleCI metadata trees from being inadvertantly
  included in the containers/repositories.

* Add default `config.yaml` and `state.json` config files to the `.gitignore` list to help facilitate building containers #4 and #5
  (those which are pre-populated with the aforementioned files from the top-level directory) without having them appear untracked.

* Add script-generated "kitchen sink" config file to `.gitignore` for much the same reason (and to avoid accidentally committing it).
