### PR TITLE
Add Nodename to the tftp template data

### DIFF
--- a/examples/vbox-uroot/support/pxelinux.cfg/default.tpl
+++ b/examples/vbox-uroot/support/pxelinux.cfg/default.tpl
@@ -6,4 +6,4 @@ MENU TITLE Main Menu
 LABEL node
     MENU LABEL Boot x86_64 Compute Node (diskless)
     KERNEL vmlinuz
-    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.iface={{.Iface}} kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}}
+    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.iface={{.Iface}} kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}} kraken.name={{.Nodename}}

--- a/examples/vbox/support/pxelinux.cfg/default.tpl
+++ b/examples/vbox/support/pxelinux.cfg/default.tpl
@@ -6,4 +6,4 @@ MENU TITLE Main Menu
 LABEL node
     MENU LABEL Boot x86_64 Compute Node (diskless)
     KERNEL vmlinuz
-    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.iface={{.Iface}} kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}}
+    APPEND console=tty1 root=/dev/ram0 initrd=initramfs.cpio.gz kraken.iface={{.Iface}} kraken.ip={{.IP}} kraken.net={{.CIDR}} kraken.id={{.ID}} kraken.parent={{.ParentIP}} kraken.name={{.Nodename}}

--- a/modules/pxe/tftp.go
+++ b/modules/pxe/tftp.go
@@ -68,6 +68,7 @@ func (px *PXE) writeToTFTP(filename string, rf io.ReaderFrom) (e error) {
 			CIDR     string
 			ID       string
 			ParentIP string
+			Nodename string
 		}
 		data := tplData{}
 		iface, _ := n.GetValue(px.cfg.SrvIfaceUrl)
@@ -78,6 +79,8 @@ func (px *PXE) writeToTFTP(filename string, rf io.ReaderFrom) (e error) {
 		subip := i.Interface().(ipv4t.IP)
 		cidr, _ := net.IPMask(subip.To4()).Size()
 		data.CIDR = strconv.Itoa(cidr)
+		i, _ = n.GetValue("/Nodename")
+		data.Nodename = i.String()
 		data.ID = n.ID().String()
 		data.ParentIP = px.selfIP.String()
 		tpl, e := template.ParseFiles(lfile + ".tpl")


### PR DESCRIPTION
This allows, e.g. `kraken.name={{ .Nodename }}` in pxelinux.cfg.tpl