### PR TITLE
Forgetfulness: use epistemology to remove state values we can no longer know

### DIFF
--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -75,12 +75,9 @@ func (sm *ServiceManager) Run(ready chan<- interface{}) {
 
 	// initialize service instances
 	for m := range Registry.ServiceInstances {
-		base := util.NodeURLJoin(sm.ctx.Self.String(), "/Services")
 		for _, si := range Registry.ServiceInstances[m] {
 			sm.log.Logf(types.LLINFO, "adding service: %s", si.ID())
 			sm.AddService(si)
-			// clearly at startup, we don't have any services running yet... but we might have a stale state left over from a reboot
-			sm.query.SetValueDsc(util.NodeURLJoin(base, si.ID()), reflect.ValueOf(pb.ServiceInstance_STOP))
 		}
 	}
 
@@ -89,6 +86,7 @@ func (sm *ServiceManager) Run(ready chan<- interface{}) {
 		for _, si := range sm.srv {
 			sm.log.Logf(types.LLDDEBUG, "starting initial service sync: %s", si.ID())
 			sm.syncService(si.ID())
+			sm.setServiceStateDsc(si.ID(), pb.ServiceInstance_STOP)
 		}
 	}()
 

--- a/core/ServiceManager.go
+++ b/core/ServiceManager.go
@@ -75,9 +75,12 @@ func (sm *ServiceManager) Run(ready chan<- interface{}) {
 
 	// initialize service instances
 	for m := range Registry.ServiceInstances {
+		base := util.NodeURLJoin(sm.ctx.Self.String(), "/Services")
 		for _, si := range Registry.ServiceInstances[m] {
 			sm.log.Logf(types.LLINFO, "adding service: %s", si.ID())
 			sm.AddService(si)
+			// clearly at startup, we don't have any services running yet... but we might have a stale state left over from a reboot
+			sm.query.SetValueDsc(util.NodeURLJoin(base, si.ID()), reflect.ValueOf(pb.ServiceInstance_STOP))
 		}
 	}
 

--- a/core/StateDifferenceEngine.go
+++ b/core/StateDifferenceEngine.go
@@ -172,6 +172,9 @@ func (n *StateDifferenceEngine) setValueDiff(url string, cur, v reflect.Value) (
 	case reflect.Struct: // maybe a message we can diff?
 		if m1, ok := cur.Addr().Interface().(proto.Message); ok {
 			// this is a proto message
+			if !v.CanAddr() {
+				return diff, fmt.Errorf("tried to set unaddressable value: %s", url)
+			}
 			if m2, ok := v.Addr().Interface().(proto.Message); ok {
 				return util.MessageDiff(m1, m2, url)
 			}

--- a/core/StateMutationEngine.go
+++ b/core/StateMutationEngine.go
@@ -1035,6 +1035,27 @@ func (sme *StateMutationEngine) nodeViolatesDeps(deps map[string]types.StateSpec
 	return
 }
 
+func (sme *StateMutationEngine) nodeForgetUnknowable(cfg, dsc types.Node) {
+	meld := sme.dscNodeMeld(cfg, dsc)
+	ms := []string{}
+	for k := range sme.mutators {
+		ms = append(ms, k)
+	}
+	for k := range sme.requires {
+		ms = append(ms, k)
+	}
+	reqs, _ := meld.GetValues(ms)
+	nn := &mutationNode{
+		spec: NewStateSpec(reqs, map[string]reflect.Value{}),
+	}
+	violations, _ := sme.nodeViolatesDeps(sme.deps, nn)
+	sme.Logf(DEBUG, "%s forgetting unknowable values: %v", cfg.ID().String(), violations)
+	for _, r := range violations {
+		v, _ := dsc.GetValue(r)
+		sme.query.SetValueDsc(util.NodeURLJoin(cfg.ID().String(), r), reflect.Zero(v.Type()))
+	}
+}
+
 func (sme *StateMutationEngine) printDeps(deps map[string]types.StateSpec) {
 	// print some nice log messages documenting our dependencies
 	for u := range deps {
@@ -1657,25 +1678,9 @@ func (sme *StateMutationEngine) emitFail(start types.Node, p *mutationPath) {
 	//  0) create a spec that mimics the current state of the node
 	//  1) set the failto value
 	//  2) remove any values that violate epistemology
+	sme.Logf(DEBUG, "%s could not devolve, setting failure %s = %s", nid, d[1], util.ValueToString(val))
 	n.SetValue(d[1], val)
-	meld := sme.dscNodeMeld(nc, n)
-	ms := []string{}
-	for k := range sme.mutators {
-		ms = append(ms, k)
-	}
-	for k := range sme.requires {
-		ms = append(ms, k)
-	}
-	reqs, _ := meld.GetValues(ms)
-	nn := &mutationNode{
-		spec: NewStateSpec(reqs, map[string]reflect.Value{}),
-	}
-	violations, _ := sme.nodeViolatesDeps(sme.deps, nn)
-	sme.Logf(DEBUG, "%s could not devolve, setting failure %s = %s and forgetting values: %v", nid, d[1], util.ValueToString(val), violations)
-	for _, r := range violations {
-		v, _ := n.GetValue(r)
-		sme.query.SetValueDsc(util.NodeURLJoin(nid.String(), r), reflect.Zero(v.Type()))
-	}
+	sme.nodeForgetUnknowable(nc, n)
 
 	// now send a discover to whatever failed state
 	url := util.NodeURLJoin(nid.String(), d[1])
@@ -1827,6 +1832,11 @@ func (sme *StateMutationEngine) updateMutation(node string, url string, val refl
 		sme.activeMutex.Unlock()
 		return
 	}
+	// let's make sure we forget anything we can't know anymore
+	nid := ct.NewNodeID(node)
+	cfg, _ := sme.query.Read(nid)
+	dsc, _ := sme.query.ReadDsc(nid)
+	sme.nodeForgetUnknowable(cfg, dsc)
 	// we should reset waiting status
 	sme.unwaitForService(m)
 	sme.activeMutex.Unlock()

--- a/core/StateSyncEngine.go
+++ b/core/StateSyncEngine.go
@@ -388,6 +388,15 @@ func (sse *StateSyncEngine) callParent(p string) {
 		sse.delNeighbor(nid)
 		return
 	}
+	// we shouldn't clobber service manager states because our parent doesn't really know about those...
+	curDsc, _ := sse.query.ReadDsc(sse.self)
+	for _, s := range curDsc.GetServices() {
+		url := ""
+		for _, u := range []string{"/Services", s.GetId(), "State"} {
+			url = util.URLPush(url, u)
+		}
+		rpd.Node.SetValue(url, reflect.ValueOf(s.State))
+	}
 	_, e = sse.query.UpdateDsc(rpd.Node)
 	if e != nil {
 		sse.Log(ERROR, e.Error())


### PR DESCRIPTION
This PR has a couple of fixes, but the big one is stripping discoverable states as they become unknowable. This makes, e.g. failures, or progressing from more to less complicated states more reliable.

We also fix the following:
- SME should set services to STOP state on initialization
- SSE shouldn't clobber service manager states on phone home
- SDE SetValues would try to address unaddressable values (we should probably check for more instances of those)
