### PR TITLE
Imageapi: don't artificially declare IDLE state

### DIFF
--- a/modules/imageapi/imageapi.go
+++ b/modules/imageapi/imageapi.go
@@ -366,15 +366,6 @@ func (is *ImageAPI) mUKtoIDLE(me *core.MutationEvent) {
 	is.mutex.Unlock()
 
 	is.discover()
-	url := util.NodeURLJoin(is.api.Self().String(), issURL)
-	is.dchan <- core.NewEvent(
-		types.Event_DISCOVERY,
-		url,
-		&core.DiscoveryEvent{
-			URL:     url,
-			ValueID: ia.ImageState_IDLE.String(),
-		},
-	)
 }
 
 func (is *ImageAPI) mANYtoACTIVE(me *core.MutationEvent) {


### PR DESCRIPTION
the UKtoIDLE mutation had a hold-over artificial injection of the ideal state that would pre-emptively declare IDLE.  This is not only unnecessary but also generated a potential race condition.