### PR TITLE
Add freebusy utility for setting free/busy states locally

### DIFF
--- a/utils/freebusy/README.md
+++ b/utils/freebusy/README.md
@@ -1,0 +1,24 @@
+# freebusy
+
+`freebusy` is a utility to set free/busy states on a local node. 
+
+It expects `kraken.id=<id>` to exist in `/proc/cmdline`.
+
+`freebusy` communicates via the Module API (gRPC).
+
+# building
+
+```
+cd $KARKEN_SRC/util/freebusy
+CGO_ENABLED=0 go build .
+```
+
+Alternatively, `freebusy` can be built into the `u-root` busybox.
+
+# using
+
+On the local node, run:
+
+```
+freebusy <free|busy>
+```

--- a/utils/freebusy/freebusy.go
+++ b/utils/freebusy/freebusy.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	pb "github.com/hpc/kraken/core/proto"
+	"github.com/hpc/kraken/lib/util"
+	"google.golang.org/grpc"
+)
+
+func usage() {
+	fmt.Printf("Usage: %s <free|busy>\n", os.Args[0])
+}
+
+var socketFile = "unix:/tmp/kraken.sock"
+var sid = "imageapi"
+var cmdline = "/proc/cmdline"
+
+var cmdRE = regexp.MustCompile(`kraken.id=([0-9a-zA-Z\-]+)`)
+
+func getUID() string {
+	d, e := ioutil.ReadFile(cmdline)
+	if e != nil {
+		log.Fatalf("failed to extract node ID; could not read kernel commandline: %v", e)
+	}
+	m := cmdRE.FindAllStringSubmatch(string(d), 1)
+	if len(m) == 0 {
+		log.Fatal("failed to extract node ID: no match foudn in kernel commandline")
+	}
+	return m[0][1]
+}
+
+func main() {
+	if len(os.Args) != 2 || (os.Args[1] != "free" && os.Args[1] != "busy") {
+		usage()
+		os.Exit(1)
+	}
+
+	var stream pb.ModuleAPI_DiscoveryInitClient
+	var conn *grpc.ClientConn
+	var e error
+	if conn, e = grpc.Dial(socketFile, grpc.WithInsecure()); e != nil {
+		log.Fatalf("failed to dial API: %v", e)
+	}
+	client := pb.NewModuleAPIClient(conn)
+	if stream, e = client.DiscoveryInit(context.Background()); e != nil {
+		log.Fatalf("failed to establish API stream: %v", e)
+	}
+
+	log.Printf("discoverying busy = %s", os.Args[1])
+	uid := getUID()
+	url := util.NodeURLJoin(uid, "/Busy")
+	event := &pb.DiscoveryEvent{
+		Id:      sid,
+		Url:     url,
+		ValueId: strings.ToUpper(os.Args[1]),
+	}
+	if e = stream.Send(event); e != nil {
+		log.Fatalf("failed to send discovery event: %v", e)
+	}
+	stream.CloseAndRecv()
+	conn.Close()
+}


### PR DESCRIPTION
The simple command `freebusy <free|busy>` is intended to be run locally on nodes to set that node to free/busy.