### PR TITLE
Don't spam the updateSetState so often

### DIFF
--- a/modules/imageapi/imageapi.go
+++ b/modules/imageapi/imageapi.go
@@ -502,7 +502,6 @@ func (is *ImageAPI) setValues(vs map[string]interface{}) {
 		is.api.Logf(types.LLERROR, "setvalues failed: %v: %v", err, vs)
 	}
 	is.mutex.Unlock()
-	is.updateSetState()
 }
 
 /////////////////////
@@ -642,6 +641,7 @@ func (is *ImageAPI) cfgChange(name, sub string) {
 			})
 		}
 	}
+	is.updateSetState()
 }
 
 // updateSetState looks at all of the individual image states and derives the set state
@@ -853,7 +853,6 @@ func (is *ImageAPI) discover() {
 	// we do a query instead of a discover because we're setting various values
 	is.api.QuerySetValueDsc(is.api.Self().String(), isURL, *dset)
 	is.mutex.Unlock()
-	is.updateSetState()
 }
 
 ////////////////////////


### PR DESCRIPTION
Leave updateSetState to the cfgChange and dscChange functions, otherwise we can double-discover things sometimes.